### PR TITLE
Don't generate nullable reference types for optional parameters of request type when nullable is not enabled for a project

### DIFF
--- a/src/XrmTools/CodeRefactoringProviders/SdkMessageRefactoringProvider.cs
+++ b/src/XrmTools/CodeRefactoringProviders/SdkMessageRefactoringProvider.cs
@@ -125,7 +125,7 @@ public class SdkMessageRefactoringProvider : CodeRefactoringProvider
 
             bool isReferenceType = typeSymbol.IsReferenceType;
             bool useNullable = field.Optional == true && (!isReferenceType || isNullableEnabled);
-            var applyNullForgiving = !useNullable && isReferenceType;
+            var applyNullForgiving = isNullableEnabled;
             bool isRequired = isNullableEnabled && field.Optional != true && typeSymbol.IsReferenceType;
 
             var typeSyntax = CreateTypeSyntax(editor, typeSymbol, useNullable);
@@ -175,7 +175,9 @@ public class SdkMessageRefactoringProvider : CodeRefactoringProvider
     private static AttributeListSyntax CreateDataContractAttribute(SemanticModel semanticModel, SyntaxGenerator generator)
     {
         var dataContractSymbol = semanticModel.Compilation.GetTypeByMetadataName("System.Runtime.Serialization.DataContractAttribute");
-        return SyntaxFactory.AttributeList(
+        return dataContractSymbol is null
+            ? throw new InvalidOperationException("DataContractAttribute type not found in compilation.")
+            : SyntaxFactory.AttributeList(
             SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Attribute((NameSyntax)generator.TypeExpression(dataContractSymbol))
                     .WithArgumentList(SyntaxFactory.AttributeArgumentList(SyntaxFactory.SingletonSeparatedList(

--- a/src/XrmTools/Environments/DataverseEnvironmentProvider.cs
+++ b/src/XrmTools/Environments/DataverseEnvironmentProvider.cs
@@ -35,12 +35,6 @@ public class DataverseEnvironmentProvider : IEnvironmentProvider
 
         if (environment?.IsValid != true) return null;
 
-        try
-        {
-            await HttpClientFactory.PreAuthenticateAsync(environment, allowInteraction);
-        }
-        catch (Exception) { }
-
         return environment;
     }
 


### PR DESCRIPTION
- Fixes #109 
- Apply null-forgiving operator based on nullable context
- Throw if DataContractAttribute type is missing in compilation
- Remove pre-authentication and exception handling from GetActiveEnvironmentAsync