### PR TITLE
feat: refactor plugin codegen for typed step inputs

### DIFF
--- a/src/XrmTools.Core/Serialization/Newtonsoft/PolymorphicContractResolver.cs
+++ b/src/XrmTools.Core/Serialization/Newtonsoft/PolymorphicContractResolver.cs
@@ -1,6 +1,7 @@
 ﻿namespace XrmTools.Serialization;
-using Newtonsoft.Json.Serialization;
+using Microsoft.VisualStudio.OLE.Interop;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -20,6 +21,11 @@ internal class PolymorphicContractResolver : DefaultContractResolver
         return property;
     }
 
+    // TODO: Fix loading private assemblies from outside appbase directory.
+    // This line causes:
+    // Exception thrown: 'System.IO.FileLoadException' in mscorlib.dll
+    // An exception of type 'System.IO.FileLoadException' occurred in mscorlib.dll but was not handled in user code
+    // Could not load file or assembly 'XrmTools.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.The private assembly was located outside the appbase directory. (Exception from HRESULT: 0x80131041)
     private bool IsPolymorphicKnownType(Type type) => type.IsArray ?
         type.GetElementType().GetCustomAttributes<KnownTypeAttribute>(true).Any(attr => attr.Type != type) :
         type.GetCustomAttributes<KnownTypeAttribute>(true).Any(attr => attr.Type != type);

--- a/src/XrmTools.Meta/Model/Configuration/PluginStepImageConfig.cs
+++ b/src/XrmTools.Meta/Model/Configuration/PluginStepImageConfig.cs
@@ -2,7 +2,7 @@
 
 using XrmTools.WebApi.Entities;
 
-public class PluginStepImageConfig : SdkMessageProcessingStepImage//, IMessageProcessingStepImageConfig
+public class PluginStepImageConfig : SdkMessageProcessingStepImage
 {
     public EntityMetadata? MessagePropertyDefinition { get; set; }
 }

--- a/src/XrmTools/CodeGenTemplates/Plugin.sbncs
+++ b/src/XrmTools/CodeGenTemplates/Plugin.sbncs
@@ -20,6 +20,8 @@ end -}}
 #nullable enable
 {{~end~}}
 using Microsoft.Xrm.Sdk;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Extensions;
 using Microsoft.Xrm.Sdk.PluginTelemetry;
@@ -35,63 +37,18 @@ using XrmTools;
 namespace {{ first_plugin_type?.namespace ?? config.default_namespace }}
 {
     {{~for plugintype in model.plugin_types~}}
+    {{~context_getter = "DependencyScope<" + plugintype.type_name + ">.Current.Require<IPluginExecutionContext>()"~}}
     {{codegen_attribute}}
     public partial class {{plugintype.type_name | last_segment }}
     {
         {{~dependencies = plugintype.dependency_graph?.dependencies~}}
         {{include 'InjectDependencies.sbncs'~}}
-    {{~if plugintype.steps.size > 0~}}
-
-    {{~for step in plugintype.steps~}}
-	    {{~target_type_name = (plugintype.steps | array.size > 1 ? step.message_name : '') + 'Target' + step.primary_entity_definition.schema_name~}}
-        {{~target_name = (plugintype.steps | array.size > 1 ? step.message_name : '') + 'Target'~}}
-	    {{include 'Target.sbncs' target_type_name}}
-	    {{~if step.images~}}
-	    {{include 'Images.sbncs'~}}
-	    {{~end~}}
-	    public {{target_type_name}} {{target_name}}
-        {
-            get => EntityOrDefault<{{target_type_name}}>(DependencyScope<{{plugintype.type_name | last_segment }}>.Current.Require<IPluginExecutionContext>().InputParameters, "Target");
-        }
-
-	    {{~for image in step.images~}}
-        {{~image_type_name = (plugintype.steps | array.size > 1 ? step.message_name : '') + image.image_type + (step.primary_entity_definition.schema_name)~}}
-        {{~image_collection_name = image.image_type == 'PreImage' ? 'PreEntityImages' : 'PostEntityImages'~}}
-	    public {{image_type_name}} {{image.name}} { get => EntityOrDefault<{{image_type_name}}>(DependencyScope<{{plugintype.type_name | last_segment }}>.Current.Require<IPluginExecutionContext>().{{image_collection_name}}, "{{image.name}}"); }
-	    {{~end~}}
-    {{~end~}}
-    {{~end~}}
-
-	    private static T{{plugintype.is_nullable_enabled ? "?" : ""}} EntityOrDefault<T>(DataCollection<string, object> keyValues, string key) where T : Entity
-        {
-            if (keyValues is null) return default;
-            return keyValues.TryGetValue(key, out var obj) ? obj is Entity entity ? entity.ToEntity<T>() : default : default;
-        }
-
-        private static T{{plugintype.is_nullable_enabled ? "?" : ""}} EntityOrDefault<T>(DataCollection<string, Entity> keyValues, string key) where T : Entity
-        {
-            if (keyValues is null) return default;
-            return keyValues.TryGetValue(key, out var entity) ? entity?.ToEntity<T>() : default;
-        }
-        {{~if !(plugintype.base_type_methods | find_method "Require")~}}
-
-        private static T Require<T>() => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Require<T>();
-        private static T Require<T>(string name) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Require<T>(name);
+        {{~if plugintype.steps.size > 0}}
+    
+        {{include 'Plugin_Steps.sbncs' plugintype~}}
         {{~end~}}
-        {{~if !(plugintype.base_type_methods | find_method "TryGet")~}}
-
-        private static bool TryGet<T>(out T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.TryGet(out instance);
-        private static bool TryGet<T>(string name, out T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.TryGet(name, out instance);
-        {{~end~}}
-        {{~if !(plugintype.base_type_methods | find_method "Set")~}}
-
-        private static T Set<T>(T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Set(instance);
-        private static T Set<T>(string name, T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Set(name, instance);
-        private static T SetAndTrack<T>(T instance) where T : IDisposable => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.SetAndTrack(instance);
-        private static T SetAndTrack<T>(string name, T instance) where T : IDisposable => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.SetAndTrack(name, instance);
-        {{~end~}}
-    {{~if plugintype.custom_api ~}}
-    {{~if plugintype.custom_api.request_parameters.size > 0~}}
+        {{~if plugintype.custom_api ~}}
+        {{~if plugintype.custom_api.request_parameters.size > 0}}
 
         private static {{plugintype.custom_api.request_type_name}} GetRequest(IExecutionContext context)
         {
@@ -142,8 +99,8 @@ namespace {{ first_plugin_type?.namespace ?? config.default_namespace }}
             {{~end~}}
             return request;
         }
-    {{~end~}}
-    {{~if plugintype.custom_api.response_properties.size > 0~}}
+        {{~end~}}
+        {{~if plugintype.custom_api.response_properties.size > 0~}}
 
         private static void SetResponse(IExecutionContext context, {{plugintype.custom_api.response_type_name}} response)
         {
@@ -187,8 +144,47 @@ namespace {{ first_plugin_type?.namespace ?? config.default_namespace }}
             {{~end~}}
             {{~end~}}
         }
-    {{~end~}}
-    {{~end~}}
+        {{~end~}}
+        {{~end~}}
+        {{~if !(plugintype.base_type_methods | find_method "EntityOrDefault")~}}
+
+	    private static T{{plugintype.is_nullable_enabled ? "?" : ""}} EntityOrDefault<T>(DataCollection<string, object> keyValues, string key) where T : Entity
+        {
+            if (keyValues is null) return default;
+            return keyValues.TryGetValue(key, out var obj) ? obj is Entity entity ? entity.ToEntity<T>() : default : default;
+        }
+        private static T{{plugintype.is_nullable_enabled ? "?" : ""}} EntityOrDefault<T>(DataCollection<string, Entity> keyValues, string key) where T : Entity
+        {
+            if (keyValues is null) return default;
+            return keyValues.TryGetValue(key, out var entity) ? entity?.ToEntity<T>() : default;
+        }
+        {{~end~}}
+        {{~if !(plugintype.base_type_methods | find_method "EntityCollectionOrDefault")~}}
+
+        private static T[] EntityCollectionOrDefault<T>(DataCollection<string, object> keyValues, string key) where T : Entity
+        {
+            if (keyValues is null) return Array.Empty<T>();
+            return keyValues.TryGetValue(key, out var obj) ? obj is EntityCollection entityCollection
+                ? entityCollection.Entities.Select(e => e.ToEntity<T>()).ToArray() : Array.Empty<T>() : Array.Empty<T>();
+        }
+        {{~end~}}
+        {{~if !(plugintype.base_type_methods | find_method "Require")~}}
+
+        private static T Require<T>() => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Require<T>();
+        private static T Require<T>(string name) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Require<T>(name);
+        {{~end~}}
+        {{~if !(plugintype.base_type_methods | find_method "TryGet")~}}
+
+        private static bool TryGet<T>(out T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.TryGet(out instance);
+        private static bool TryGet<T>(string name, out T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.TryGet(name, out instance);
+        {{~end~}}
+        {{~if !(plugintype.base_type_methods | find_method "Set")~}}
+
+        private static T Set<T>(T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Set(instance);
+        private static T Set<T>(string name, T instance) => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.Set(name, instance);
+        private static T SetAndTrack<T>(T instance) where T : IDisposable => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.SetAndTrack(instance);
+        private static T SetAndTrack<T>(string name, T instance) where T : IDisposable => DependencyScope<{{plugintype.type_name | last_segment}}>.Current.SetAndTrack(name, instance);
+        {{~end~}}
     }
     {{~end~}}
 }

--- a/src/XrmTools/CodeGenTemplates/Plugin_Step_Inputs.sbncs
+++ b/src/XrmTools/CodeGenTemplates/Plugin_Step_Inputs.sbncs
@@ -1,0 +1,69 @@
+﻿{{~is_entity_required = false~}}
+{{~for field in step.message.pairs[0].request[0].fields~}}
+{{~field_type = field.clr_parser == null || field.clr_parser == "" ? field.parser : field.clr_parser
+    index_of_comma = field_type | string.index_of ','
+    field_type = index_of_comma > -1 ? (field_type | string.slice 0 index_of_comma) : field_type
+    if (field_type | string.starts_with "System.Nullable`1[[")
+    field_type = field_type | string.slice 19 ((field_type | string.size) - 19 - 2)
+    force_nullable = true
+    end
+    field_type = field_type | last_segment~}}
+{{~if (field_type == "EntityCollection")
+    field_type = entity_type_name + "[]"
+    field_getter = "EntityCollectionOrDefault<" + entity_type_name + ">(" + context_getter + ".InputParameters, \"" + field.name + "\")"
+    is_entity_required = true
+else if (field_type == "Entity" || field_type == "EntitySelector")
+    field_type = entity_type_name
+    field_getter = "EntityOrDefault<" + entity_type_name + ">(" + context_getter + ".InputParameters, \"" + field.name + "\")"
+    is_entity_required = true
+else if (field_type == "DynamicEntityRequestMoniker")
+    field_type = "EntityReference"
+    field_getter = context_getter + ".InputParameters.TryGetValue(\"" + field.name + "\", out EntityReference " + (field.name | string.downcase) + ") ? " + (field.name | string.downcase) + " : default"
+else if (field_type == "MonikerSelector" || field_type == "Microsoft.Xrm.Sdk.EntityReference")
+    field_type = "EntityReference"
+    field_getter = context_getter + ".InputParameters.TryGetValue(\"" + field.name + "\", out EntityReference " + (field.name | string.downcase) + ") ? " + (field.name | string.downcase) + " : default"
+else
+    case field_type
+    when "String"
+        field_type = "string"
+    when "Int32"
+        field_type = "int"
+    when "Int64"
+        field_type = "long"
+    when "Boolean"
+        field_type = "bool"
+    when "Decimal"
+        field_type = "decimal"
+    when "Double"
+        field_type = "double"
+    when "Guid"
+        field_type = "Guid"
+    when "Byte[]"
+        field_type = "byte[]"
+    when "ColumnSetBase"
+        field_type = "ColumnSet"
+    when "Query"
+        field_type = "QueryBase"
+    when "CrmDateTime"
+        field_type = "DateTime"
+    when "SetStateRequestMoniker", "SecurityPrincipal" #team, user or organization
+        field_type = "EntityReference" 
+    when "State" # Not tested on SetState
+        field_type = "OptionSetValue"
+    end
+    field_getter = context_getter + ".InputParameters.TryGetValue(\"" + field.name + "\", out " + field_type + " _" + (field.name | string.downcase) + ") ? _" + (field.name | string.downcase) + " : default"
+end
+if plugintype.is_nullable_enabled && field.optional || force_nullable
+    field_type += "?"
+else if plugintype.is_nullable_enabled && !field.optional
+    field_getter += "!"
+end
+~}}
+public static {{field_type}} {{field.name | string.capitalize}}
+{
+    get => {{field_getter}};
+}
+    
+{{~end~}}
+{{~if is_entity_required~}}
+{{include 'Target.sbncs' entity_type_name}}{{~end~}}

--- a/src/XrmTools/CodeGenTemplates/Plugin_Steps.sbncs
+++ b/src/XrmTools/CodeGenTemplates/Plugin_Steps.sbncs
@@ -1,0 +1,32 @@
+{{~for step in plugintype.steps~}}
+{{~entity_type_name = step.message_name + step.primary_entity_definition.schema_name + "Entity"~}}
+{{~if (plugintype.steps | array.size > 1) || (plugintype.steps[0].message.pairs[0].request[0].fields | array.size > 1)~}}
+public static class {{(plugintype.steps | array.size > 1) ? step.message_name : ""}}InputParameters
+{
+    {{include 'Plugin_Step_Inputs.sbncs'~}}
+}
+{{~else~}}
+{{include 'Plugin_Step_Inputs.sbncs'~}}
+{{~end~}}    
+{{~if step.images~}}
+{{include 'Images.sbncs'~}}
+{{~end~}}
+{{~for image in step.images~}}
+{{~image_type_name = (plugintype.steps | array.size > 1 ? step.message_name : '') + image.image_type + (step.primary_entity_definition.schema_name)~}}
+{{~image_collection_name = image.image_type == 'PreImage' ? 'PreEntityImages' : 'PostEntityImages'~}}
+{{~if step.message_name | string.ends_with('Multiple')~}}
+public {{image_type_name}}[] {{image.name}}s
+{
+    get
+    {
+        var imagesCollection = ((IPluginExecutionContext4)DependencyScope<AccountMultiGreetingPlugin>.Current.Require<IPluginExecutionContext>()).{{image_collection_name}}Collection;
+        return imagesCollection != null 
+            ? imagesCollection.Select(col => EntityOrDefault<{{image_type_name}}>(col, "{{image.name}}")).ToArray()
+            : Array.Empty<{{image_type_name}}>();
+    }
+}
+{{~else~}}
+public {{image_type_name}} {{image.name}} { get => EntityOrDefault<{{image_type_name}}>(DependencyScope<{{plugintype.type_name | last_segment }}>.Current.Require<IPluginExecutionContext>().{{image_collection_name}}, "{{image.name}}"); }
+{{~end~}}
+{{~end~}}
+{{~end~}}

--- a/src/XrmTools/CodeGenTemplates/Target.sbncs
+++ b/src/XrmTools/CodeGenTemplates/Target.sbncs
@@ -1,6 +1,6 @@
 [EntityLogicalName("{{step.primary_entity_definition.logical_name}}")]
-{{~parent_type_name = target_type_name~}}
-public class {{target_type_name}} : Entity
+{{~parent_type_name = entity_type_name~}}
+public class {{entity_type_name}} : Entity
 {
 	public static class Meta
 	{

--- a/src/XrmTools/Commands/SetCustomToolEntityGeneratorCommand.cs
+++ b/src/XrmTools/Commands/SetCustomToolEntityGeneratorCommand.cs
@@ -43,6 +43,7 @@ internal sealed class SetCustomToolEntityGeneratorCommand : BaseCommand<SetCusto
                 Path.GetFileNameWithoutExtension(file.FullPath)) + ".g.cs";
             if (!File.Exists(genFilePath)) await FileHelper.AddItemAsync(genFilePath, "", file);
             var genFile = await PhysicalFile.FromFileAsync(genFilePath);
+            if (genFile is null) return;
             await genFile.TrySetAttributeAsync(PhysicalFileAttribute.AutoGen, true);
             await genFile.TrySetAttributeAsync(PhysicalFileAttribute.DesignTime, true);
             await genFile.TrySetAttributeAsync(PhysicalFileAttribute.DependentUpon, Path.GetFileName(file.FullPath));

--- a/src/XrmTools/XrmGen.csproj
+++ b/src/XrmTools/XrmGen.csproj
@@ -379,6 +379,12 @@
     <Content Include="FetchXmlViewer\assets\index-Df-1zudZ.js.map">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="CodeGenTemplates\Plugin_Steps.sbncs">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="CodeGenTemplates\Plugin_Step_Inputs.sbncs">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="FetchXmlViewer.WebAssets.targets" />
     <None Include="IncludeNuGetResolvedAssets.targets" />
     <None Include="PrepareImageManifest.targets" />

--- a/src/XrmTools/XrmToolsPackage.cs
+++ b/src/XrmTools/XrmToolsPackage.cs
@@ -110,6 +110,7 @@ using Task = System.Threading.Tasks.Task;
 [ProvideService(typeof(ISettingsProvider), IsAsyncQueryable = true, IsCacheable = true, IsFreeThreaded = true)]
 [ProvideOptionPage(typeof(OptionsProvider.GeneralOptions), Vsix.Name, "General", 0, 0, true, SupportsProfiles = true)]
 [ProvideOptionPage(typeof(OptionsProvider.FetchXmlOptions), Vsix.Name, "FetchXML", 0, 0, true, SupportsProfiles = true)]
+[ProvideBindingPath]
 public sealed partial class XrmToolsPackage : ToolkitPackage
 {
     private static readonly object _lock = new();


### PR DESCRIPTION
Major overhaul of plugin code generation:
- Introduce new templates for step input/output (`Plugin_Steps.sbncs`, `Plugin_Step_Inputs.sbncs`)
- Generate strongly typed static accessors for input parameters, images, and targets based on SDK message metadata
- Add full SDK message metadata retrieval for each step (`AddMessageMetadataAsync`, `GetByNameWithDescendantsNoFiltersAsync`)
- Refactor main plugin template to delegate step code to new templates, reducing duplication
- Consistent entity type naming and target class generation per step
- Add helper methods for entity/collection access if not present in base type
- Update VSIX project to include new templates
- Miscellaneous fixes: using directives, comments, file handling

Improves type safety, discoverability, and maintainability for complex plugin scenarios.