### PR TITLE
Error for sdk messages without entity

### DIFF
--- a/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
+++ b/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
@@ -4,7 +4,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ImplicitUsings>disable</ImplicitUsings>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
     <Authors>Reza Niroomand</Authors>
     <PackageIcon>XrmTools_256.png</PackageIcon>

--- a/src/XrmTools.Meta.Attributes/src/CustomApiAttribute.cs
+++ b/src/XrmTools.Meta.Attributes/src/CustomApiAttribute.cs
@@ -12,7 +12,7 @@
         public string Name { get; set; } = string.Empty;
         public string UniqueName { get; }
         public string Description { get; set; } = string.Empty;
-        public ProcessingStepTypes StepType { get; set; } = ProcessingStepTypes.SyncAndAsync;
+        public ProcessingStepTypes StepType { get; set; } = ProcessingStepTypes.None;
         public BindingTypes BindingType { get; set; } = BindingTypes.Global;
         public string BoundEntityLogicalName { get; set; } = string.Empty;
         public string ExecutePrivilegeName { get; set; } = string.Empty;

--- a/src/XrmTools/CodeGenTemplates/Plugin_Steps.sbncs
+++ b/src/XrmTools/CodeGenTemplates/Plugin_Steps.sbncs
@@ -1,4 +1,5 @@
 {{~for step in plugintype.steps~}}
+{{~if step.primary_entity_definition~}}
 {{~entity_type_name = step.message_name + step.primary_entity_definition.schema_name + "Entity"~}}
 {{~if (plugintype.steps | array.size > 1) || (plugintype.steps[0].message.pairs[0].request[0].fields | array.size > 1)~}}
 public static class {{(plugintype.steps | array.size > 1) ? step.message_name : ""}}InputParameters
@@ -27,6 +28,7 @@ public {{image_type_name}}[] {{image.name}}s
 }
 {{~else~}}
 public {{image_type_name}} {{image.name}} { get => EntityOrDefault<{{image_type_name}}>(DependencyScope<{{plugintype.type_name | last_segment }}>.Current.Require<IPluginExecutionContext>().{{image_collection_name}}, "{{image.name}}"); }
+{{~end~}}
 {{~end~}}
 {{~end~}}
 {{~end~}}

--- a/src/XrmTools/CustomMonikers.imagemanifest
+++ b/src/XrmTools/CustomMonikers.imagemanifest
@@ -3,7 +3,7 @@
 <!-- Version: 17.0.0.4 -->
 <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
-    <String Name="Resources" Value="/XrmTools;v1.5.8.0;Component/Resources" />
+    <String Name="Resources" Value="/XrmTools;v1.5.9.0;Component/Resources" />
     <Guid Name="AssetsGuid" Value="{b11584c1-89bd-47a3-b6a4-05b05dd5fc13}" />
     <ID Name="ApplyToDataverse" Value="10" />
     <ID Name="Dataverse" Value="20" />

--- a/src/XrmTools/Services/PluginRegistrationService.cs
+++ b/src/XrmTools/Services/PluginRegistrationService.cs
@@ -414,8 +414,10 @@ internal sealed class PluginRegistrationService(
     private async Task<Dictionary<string, SdkMessage>> FetchSdkMessagesAsync(PluginAssemblyConfig config, CancellationToken cancellationToken)
     {
         var stepEntities = config.PluginTypes
-            .SelectMany(p => p.Steps.Select(s => s.PrimaryEntityName))
+            .SelectMany(p => p.Steps.Select(s => s.PrimaryEntityName)
+            .Where(s => !string.IsNullOrEmpty(s)))
             .Distinct()
+            .Union(["none"])
             .ToArray();
 
         if (stepEntities == null || stepEntities.Length == 0)

--- a/src/XrmTools/Xrm/Repositories/SdkMessageRepository.cs
+++ b/src/XrmTools/Xrm/Repositories/SdkMessageRepository.cs
@@ -29,7 +29,7 @@ internal interface ISdkMessageRepository : IXrmRepository
 
 internal class SdkMessageRepository(IWebApiService service, ILogger logger) : XrmRepository(service, new SlidingCacheConfiguration()), ISdkMessageRepository
 {
-    private const string sdkMessageQueryForEntities = "sdkmessages?$filter=sdkmessageid_sdkmessagefilter/any(n:({0}) and n/iscustomprocessingstepallowed eq true)&$expand=sdkmessageid_sdkmessagefilter($filter=({1}) and iscustomprocessingstepallowed eq true)";
+    private const string sdkMessageQueryForEntities = "sdkmessages?$select=name&$filter=sdkmessageid_sdkmessagefilter/any(n:({0}) and n/iscustomprocessingstepallowed eq true)&$expand=sdkmessageid_sdkmessagefilter($filter=({1}) and iscustomprocessingstepallowed eq true;$select=primaryobjecttypecode)";
     private const string sdkMessageQuerySingle = "sdkmessages?$filter=sdkmessageid_sdkmessagefilter/any(n:n/primaryobjecttypecode eq '{0}' and n/iscustomprocessingstepallowed eq true)&$expand=sdkmessageid_sdkmessagefilter($filter=primaryobjecttypecode eq '{0}' and iscustomprocessingstepallowed eq true)";
     private const string sdkMessageQueryForPlugins_WithExpand = "sdkmessages?$select=name&$filter=sdkmessageid_sdkmessagefilter/any(n:n/iscustomprocessingstepallowed eq true)&$expand=sdkmessageid_sdkmessagefilter($filter=iscustomprocessingstepallowed eq true)";
     private const string sdkMessageQueryForPlugins = "sdkmessages?$count=true&$select=name&$filter=sdkmessageid_sdkmessagefilter/any(f:f/iscustomprocessingstepallowed eq true)";


### PR DESCRIPTION
When using bulb action to generate registration attributes for global messages (i.e. messages without associated entity like "Associate") or when registering plugins for these messages Xrm Tools displayed an error message.

This issue has been fixed while also the retrieval of sdkmessages has been optimized for better performance.