### PR TITLE
chore(csproj): remove explicit C# 13.0 langversion

### DIFF
--- a/src/Templates/XrmTools.PluginProjectTemplate/ProjectTemplate.csproj
+++ b/src/Templates/XrmTools.PluginProjectTemplate/ProjectTemplate.csproj
@@ -8,7 +8,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <ProjectTypeGuids>{4C25E9B5-9FA6-436c-8E19-B395D2A65FAF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <LangVersion>13.0</LangVersion>
     <Deterministic>true</Deterministic>
     <AssemblyTitle>$safeprojectname$</AssemblyTitle>
     <Product>$safeprojectname$</Product>


### PR DESCRIPTION
Removed the <LangVersion> property from ProjectTemplate.csproj to allow the compiler to use the default language version for the target framework. This enhances compatibility and enables automatic adoption of newer language features.