### PR TITLE
fix: update packages to support VS22022 and improve env command logic

### DIFF
--- a/src/Tests/XrmTools.Tests/XrmTools.Tests.csproj
+++ b/src/Tests/XrmTools.Tests/XrmTools.Tests.csproj
@@ -52,6 +52,8 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
     <!-- VS2022 supports System.Threading.Tasks.Extensions supports 4.6.0-->
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" NoWarn="NU1605" />
+	<!-- VS2022 only supports System.Text.Json 9.0.0 -->
+	<PackageReference Include="System.Text.Json" Version="9.0.0" NoWarn="NU1605"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\XrmTools.Core\XrmTools.Core.csproj">

--- a/src/Tests/XrmTools.Tests/XrmTools.Tests.csproj
+++ b/src/Tests/XrmTools.Tests/XrmTools.Tests.csproj
@@ -50,6 +50,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
+    <!-- VS2022 supports System.Threading.Tasks.Extensions supports 4.6.0-->
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\XrmTools.Core\XrmTools.Core.csproj">

--- a/src/Tests/XrmTools.WebApi.Tests/XrmTools.WebApi.Tests.csproj
+++ b/src/Tests/XrmTools.WebApi.Tests/XrmTools.WebApi.Tests.csproj
@@ -24,7 +24,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72"/>
     <PackageReference Include="Scriban" Version="7.1.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.14" />
+    <!-- VS2022 supports System.Text.Json supports 9.0.0-->
+    <PackageReference Include="System.Text.Json" Version="9.0.0" NoWarn="NU1605" />
     <PackageReference Include="xunit.v3">
       <Version>3.2.2</Version>
     </PackageReference>

--- a/src/XrmTools.WebApi/Messages/DownloadFileRequest.cs
+++ b/src/XrmTools.WebApi/Messages/DownloadFileRequest.cs
@@ -3,11 +3,13 @@ namespace XrmTools.WebApi.Messages;
 
 using System;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 /// <summary>
 /// Contains the data to retrieve a file column value
 /// 
-public sealed class DownloadFileRequest : HttpRequestMessage
+public sealed class DownloadFileRequest : WebApiRequest<DownloadFileResponse>
 {
     /// <summary>
     /// Initializes the DownloadFileRequest
@@ -27,5 +29,8 @@ public sealed class DownloadFileRequest : HttpRequestMessage
             uriString: uriString,
             uriKind: UriKind.Relative);
     }
+
+    public override Task<DownloadFileResponse> CreateResponseAsync(HttpResponseMessage raw, CancellationToken ct)
+        => DownloadFileResponse.FromAsync(raw);
 }
 #nullable restore

--- a/src/XrmTools.WebApi/Messages/DownloadFileResponse.cs
+++ b/src/XrmTools.WebApi/Messages/DownloadFileResponse.cs
@@ -1,19 +1,21 @@
 ﻿namespace XrmTools.WebApi.Messages;
 
 using System.Net.Http;
+using System.Threading.Tasks;
 
 /// <summary>
 /// Contains the data from the GetColumnValueRequest.
 /// </summary>
-/// <remarks>
-/// This class must be instantiated by either:
-/// - The Service.SendAsync<T> method
-/// - The HttpResponseMessage.As<T> extension in Extensions.cs
-/// </remarks>
-public sealed class DownloadFileResponse : HttpResponseMessage
+public sealed class DownloadFileResponse
 {
     /// <summary>
     /// The requested file column  value.
     /// </summary>
-    public byte[] File => Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+    public byte[]? File {  get; private set; }
+
+    private DownloadFileResponse(byte[]? file) => File = file;
+
+    internal async static Task<DownloadFileResponse> FromAsync(HttpResponseMessage raw)
+        => new(await raw.Content.ReadAsByteArrayAsync().ConfigureAwait(false));
+
 }

--- a/src/XrmTools/Commands/ManageEnvironmentsCommand.cs
+++ b/src/XrmTools/Commands/ManageEnvironmentsCommand.cs
@@ -34,6 +34,8 @@ internal class ManageEnvironmentsCommand : BaseCommand<ManageEnvironmentsCommand
     private const string ManageItem = "Manage environments...";
     private const string DefaultItem = "Select environment...";
 
+    private string _currentEnvironmentName = DefaultItem;
+
     [Import]
     public IEnvironmentEditor EnvironmentEditor { get; set; }
 
@@ -44,6 +46,7 @@ internal class ManageEnvironmentsCommand : BaseCommand<ManageEnvironmentsCommand
     {
         var componentModel = await Package.GetServiceAsync<SComponentModel, IComponentModel>();
         componentModel?.DefaultCompositionService.SatisfyImportsOnce(this);
+        await RefreshCurrentEnvironmentAsync();
     }
 
     protected override void BeforeQueryStatus(EventArgs e)
@@ -59,21 +62,28 @@ internal class ManageEnvironmentsCommand : BaseCommand<ManageEnvironmentsCommand
 
         if (args.OutValue != IntPtr.Zero)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var activeEnvironment = await EnvironmentProvider.GetActiveEnvironmentAsync(true);
-            var environmentName = activeEnvironment?.Name ?? DefaultItem;
-            if (args.OutValue != IntPtr.Zero) Marshal.GetNativeVariantForObject(environmentName, args.OutValue);
+            // Must be synchronous - no await allowed before marshaling
+            Marshal.GetNativeVariantForObject(_currentEnvironmentName, args.OutValue);
         }
         else if (args.InValue is string selected)
         {
             if (selected == ManageItem)
             {
                 await EnvironmentEditor.EditEnvironmentsAsync();
+                await RefreshCurrentEnvironmentAsync();
                 return;
             }
 
             await SetActiveEnvironmentAsync(selected);
         }
+    }
+
+    private async Task RefreshCurrentEnvironmentAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var activeEnvironment = await EnvironmentProvider.GetActiveEnvironmentAsync(false);
+        _currentEnvironmentName = activeEnvironment?.Name ?? DefaultItem;
+        //Command.Text = _currentEnvironmentName;
     }
 
     private async Task SetActiveEnvironmentAsync(string name)
@@ -90,6 +100,7 @@ internal class ManageEnvironmentsCommand : BaseCommand<ManageEnvironmentsCommand
             return;
         }
         await EnvironmentProvider.SetActiveEnvironmentAsync(environment, true);
+        await RefreshCurrentEnvironmentAsync();
     }
 }
 

--- a/src/XrmTools/WebApi/Methods/DownloadFile.cs
+++ b/src/XrmTools/WebApi/Methods/DownloadFile.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+namespace XrmTools.WebApi.Methods;
+
+using System.Threading;
+using System.Threading.Tasks;
+using XrmTools.WebApi.Messages;
+
+internal static partial class Extensions
+{
+    public static async Task<byte[]?> DownloadFileAsync(
+        this IWebApiService service,
+        EntityReference entityReference,
+        string property,
+        bool returnFullSizedImage = false,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new DownloadFileRequest(entityReference, property, returnFullSizedImage);
+        var response = await service.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return response.File;
+    }
+}

--- a/src/XrmTools/XrmTools.csproj
+++ b/src/XrmTools/XrmTools.csproj
@@ -256,6 +256,7 @@
     <Compile Include="WebApi\Methods\CreateRetrieve.cs" />
     <Compile Include="WebApi\Methods\Delete.cs" />
     <Compile Include="WebApi\Methods\DeleteColumnValue.cs" />
+    <Compile Include="WebApi\Methods\DownloadFile.cs" />
     <Compile Include="WebApi\Methods\Extensions.cs" />
     <Compile Include="WebApi\Methods\FetchXml.cs" />
     <Compile Include="WebApi\Methods\GetColumnValue.cs" />
@@ -477,7 +478,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.551" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <!-- CommunityToolkit.Mvvm 8.4.1+ use Microsoft.Bcl.AsyncInterfaces v10.0.0.1 which is not compatible with VS2022 -->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="GuiLabs.Language.Xml" Version="1.2.119" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
@@ -507,11 +509,13 @@
     </PackageReference>
     <!-- Scriban Source Embedding requires Microsoft.CSharp, System.Threading.Tasks.Extensions, and PolySharp -->
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <!-- VS2022 only supports System.Threading.Tasks.Extensions 4.6.0 -->
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
     <PackageReference Include="Scriban" Version="7.1.0" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageReference Include="System.Runtime.Caching" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.14" />
+    <!-- VS2022 only supports System.Text.Json 9.0.0 -->
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/XrmTools/XrmTools.csproj
+++ b/src/XrmTools/XrmTools.csproj
@@ -510,12 +510,12 @@
     <!-- Scriban Source Embedding requires Microsoft.CSharp, System.Threading.Tasks.Extensions, and PolySharp -->
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <!-- VS2022 only supports System.Threading.Tasks.Extensions 4.6.0 -->
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" NoWarn="NU1605" />
     <PackageReference Include="Scriban" Version="7.1.0" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageReference Include="System.Runtime.Caching" Version="8.0.1" />
     <!-- VS2022 only supports System.Text.Json 9.0.0 -->
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" NoWarn="NU1605"/>
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Update NuGet package versions for VS2022 compatibility, downgrading System.Threading.Tasks.Extensions, System.Text.Json, and CommunityToolkit.Mvvm as needed, with explanatory comments. Suppress NU1605 warnings in test projects. Add WebApi/Methods/DownloadFile.cs to XrmTools.csproj. Refactor ManageEnvironmentsCommand to cache and refresh the current environment name, ensuring UI updates after environment changes and avoiding async calls before marshaling.