### PR TITLE
feat(meta-attributes): add public accessibility switch for generated types

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,3 +3,4 @@
 ## Project Guidelines
 - Code generation must respect both #nullable enabled and #nullable disabled scenarios in generated code, and avoid nullable warnings where practical.
 - Generated code must support both #nullable enabled and disabled scenarios, as Dataverse sets missing primitive Custom API request parameters to their CLR defaults.
+- XrmTools.WebApi should consume public XrmTools.Meta.Attributes types, and the XrmTools.Meta.Attributes package version/reference should be increased and updated when enabling this behavior.

--- a/src/Analyzers/XrmTools.Analyzers.Test/XrmTools.Analyzers.Test.csproj
+++ b/src/Analyzers/XrmTools.Analyzers.Test/XrmTools.Analyzers.Test.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\XrmTools.Analyzers.CodeFixes\XrmTools.Analyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\XrmTools.Analyzers\XrmTools.Analyzers.csproj" />
+    <ProjectReference Include="..\..\XrmTools.Meta.Attributes.SourceGenerator\XrmTools.Meta.Attributes.SourceGenerator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Analyzers/XrmTools.Analyzers.Test/XrmToolsMetaAttributesGeneratorTests.cs
+++ b/src/Analyzers/XrmTools.Analyzers.Test/XrmToolsMetaAttributesGeneratorTests.cs
@@ -1,0 +1,161 @@
+namespace XrmTools.Analyzers.Test;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Xunit;
+using XrmTools.Meta.Attributes.SourceGenerator;
+
+public class XrmToolsMetaAttributesGeneratorTests
+{
+    [Fact]
+    public void GeneratedTypes_AreInternalByDefault()
+    {
+        var compilation = RunGenerator(CreateCompilation("public sealed class Consumer { }"));
+
+        var pluginAttribute = compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.PluginAttribute");
+        var stages = compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.Stages");
+
+        Assert.NotNull(pluginAttribute);
+        Assert.NotNull(stages);
+        Assert.Equal(Accessibility.Internal, pluginAttribute!.DeclaredAccessibility);
+        Assert.Equal(Accessibility.Internal, stages!.DeclaredAccessibility);
+    }
+
+    [Fact]
+    public void GeneratedTypes_CanBePublic_WhenEnabled()
+    {
+        var compilation = RunGenerator(CreateCompilation("public sealed class Consumer { }"), usePublicAccessibility: true);
+
+        var pluginAttribute = compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.PluginAttribute");
+        var stages = compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.Stages");
+
+        Assert.NotNull(pluginAttribute);
+        Assert.NotNull(stages);
+        Assert.Equal(Accessibility.Public, pluginAttribute!.DeclaredAccessibility);
+        Assert.Equal(Accessibility.Public, stages!.DeclaredAccessibility);
+    }
+
+    [Fact]
+    public void DependencyScope_IsOnlyGenerated_WhenXrmSdkIsReferenced()
+    {
+        var withoutXrmSdk = RunGenerator(CreateCompilation("public sealed class Consumer { }"));
+        var withXrmSdk = RunGenerator(
+            CreateCompilation("public sealed class Consumer { }", CreateXrmSdkMetadataReference()));
+
+        Assert.Null(withoutXrmSdk.GetTypeByMetadataName("XrmTools.DependencyScope`1"));
+        Assert.NotNull(withXrmSdk.GetTypeByMetadataName("XrmTools.DependencyScope`1"));
+    }
+
+    [Fact]
+    public void GeneratedSources_Compile_WithNullableEnabled()
+    {
+        var compilation = RunGenerator(CreateCompilation("#nullable enable\npublic sealed class Consumer { }"));
+
+        AssertNoErrors(compilation);
+    }
+
+    [Fact]
+    public void GeneratedSources_Compile_WithNullableDisabled()
+    {
+        var compilation = RunGenerator(CreateCompilation("#nullable disable\npublic sealed class Consumer { }"));
+
+        AssertNoErrors(compilation);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, MetadataReference? additionalReference = null)
+    {
+        List<MetadataReference> references = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+            .Split(Path.PathSeparator)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToList();
+
+        if (additionalReference is not null)
+        {
+            references.Add(additionalReference);
+        }
+
+        return CSharpCompilation.Create(
+            assemblyName: "GeneratorConsumer",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static CSharpCompilation RunGenerator(CSharpCompilation compilation, bool usePublicAccessibility = false)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new XrmToolsMetaAttributesGenerator().AsSourceGenerator()],
+            parseOptions: (CSharpParseOptions?)compilation.SyntaxTrees.First().Options,
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(usePublicAccessibility));
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+
+        Assert.DoesNotContain(generatorDiagnostics, static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        return (CSharpCompilation)outputCompilation;
+    }
+
+    private static MetadataReference CreateXrmSdkMetadataReference()
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Microsoft.Xrm.Sdk",
+            syntaxTrees: [CSharpSyntaxTree.ParseText("namespace Microsoft.Xrm.Sdk { public interface IPlugin { } }")],
+            references: ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+                .Split(Path.PathSeparator)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(static path => MetadataReference.CreateFromFile(path)),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        stream.Position = 0;
+
+        return MetadataReference.CreateFromStream(stream);
+    }
+
+    private static void AssertNoErrors(CSharpCompilation compilation)
+    {
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.DoesNotContain(diagnostics, static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        private static readonly AnalyzerConfigOptions Empty = new TestAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty);
+        private readonly AnalyzerConfigOptions _globalOptions;
+
+        public TestAnalyzerConfigOptionsProvider(bool usePublicAccessibility)
+        {
+            _globalOptions = new TestAnalyzerConfigOptions(
+                usePublicAccessibility
+                    ? ImmutableDictionary<string, string>.Empty.Add("build_property.XrmToolsMetaAttributesUsePublicAccessibility", bool.TrueString)
+                    : ImmutableDictionary<string, string>.Empty);
+        }
+
+        public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => Empty;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => Empty;
+    }
+
+    private sealed class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+    {
+        private readonly ImmutableDictionary<string, string> _values;
+
+        public TestAnalyzerConfigOptions(ImmutableDictionary<string, string> values)
+        {
+            _values = values;
+        }
+
+        public override bool TryGetValue(string key, out string value) => _values.TryGetValue(key, out value!);
+    }
+}

--- a/src/Analyzers/XrmTools.Analyzers.Test/XrmToolsMetaAttributesNuGetTests.cs
+++ b/src/Analyzers/XrmTools.Analyzers.Test/XrmToolsMetaAttributesNuGetTests.cs
@@ -1,0 +1,124 @@
+namespace XrmTools.Analyzers.Test;
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+public class XrmToolsMetaAttributesNuGetTests
+{
+    [Theory]
+    [InlineData("net462")]
+    [InlineData("net48")]
+    public async Task Package_DefaultAccessibility_RemainsInternal(string targetFramework)
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var packageVersion = "1.1.3-local";
+            var feedPath = Path.Combine(testRoot, "feed");
+            Directory.CreateDirectory(feedPath);
+
+            var packResult = await RunDotNetAsync($"pack \"{GetPackageProjectPath()}\" -o \"{feedPath}\" -p:PackageVersion={packageVersion}");
+            Assert.True(packResult.ExitCode == 0, packResult.Output);
+
+            var consumerBuildResult = await RunDotNetAsync(
+                $"build \"{GetConsumerProjectPath()}\" -p:TargetFramework={targetFramework} -p:XrmToolsMetaAttributesRestoreSources=\"{feedPath}\" -p:XrmToolsMetaAttributesPackageVersion={packageVersion}");
+
+            Assert.True(consumerBuildResult.ExitCode == 0, consumerBuildResult.Output);
+
+            var buildResult = await RunDotNetAsync(
+                $"build \"{GetInspectorProjectPath()}\" -p:TargetFramework={targetFramework}");
+
+            Assert.True(buildResult.ExitCode != 0, buildResult.Output);
+            Assert.Contains("CS0122", buildResult.Output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("net462")]
+    [InlineData("net48")]
+    public async Task Package_PublicAccessibility_MakesTypesPublic(string targetFramework)
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var packageVersion = "1.1.3-local";
+            var feedPath = Path.Combine(testRoot, "feed");
+            Directory.CreateDirectory(feedPath);
+
+            var packResult = await RunDotNetAsync($"pack \"{GetPackageProjectPath()}\" -o \"{feedPath}\" -p:PackageVersion={packageVersion}");
+            Assert.True(packResult.ExitCode == 0, packResult.Output);
+
+            var consumerBuildResult = await RunDotNetAsync(
+                $"build \"{GetConsumerProjectPath()}\" -p:TargetFramework={targetFramework} -p:XrmToolsMetaAttributesRestoreSources=\"{feedPath}\" -p:XrmToolsMetaAttributesPackageVersion={packageVersion} -p:XrmToolsMetaAttributesUsePublicAccessibility=true");
+
+            Assert.True(consumerBuildResult.ExitCode == 0, consumerBuildResult.Output);
+
+            var buildResult = await RunDotNetAsync(
+                $"build \"{GetInspectorProjectPath()}\" -p:TargetFramework={targetFramework}");
+
+            Assert.True(buildResult.ExitCode == 0, buildResult.Output);
+        }
+        finally
+        {
+            Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    private static string GetConsumerProjectPath() => Path.Combine(GetRepositoryRoot(), "src", "Tests", "XrmTools.Meta.Attributes.NuGet", "Consumer", "Consumer.csproj");
+
+    private static string GetPackageProjectPath() => Path.Combine(GetRepositoryRoot(), "src", "XrmTools.Meta.Attributes.Package", "XrmTools.Meta.Attributes.Package.msbuildproj");
+
+    private static string GetInspectorProjectPath() => Path.Combine(GetRepositoryRoot(), "src", "Tests", "XrmTools.Meta.Attributes.NuGet", "Inspector", "Inspector.csproj");
+
+    private static string GetRepositoryRoot() => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
+
+    private static string CreateTestRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "XrmTools.Meta.Attributes.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static async Task<CommandResult> RunDotNetAsync(string arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = GetRepositoryRoot(),
+        };
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var standardOutput = await process!.StandardOutput.ReadToEndAsync();
+        var standardError = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return new CommandResult(process.ExitCode, standardOutput + Environment.NewLine + standardError);
+    }
+
+    private readonly struct CommandResult
+    {
+        public CommandResult(int exitCode, string output)
+        {
+            ExitCode = exitCode;
+            Output = output;
+        }
+
+        public int ExitCode { get; }
+
+        public string Output { get; }
+    }
+}

--- a/src/Testbed/Classic/ClassicPluginsCS13/AccountGreetingPlugin.cs
+++ b/src/Testbed/Classic/ClassicPluginsCS13/AccountGreetingPlugin.cs
@@ -6,7 +6,7 @@ using XrmTools.Meta.Attributes;
 namespace XrmGenTest;
 
 [Plugin]
-[Step("Create", "account", "name, description, accountnumber", Stages.PostOperation, ExecutionMode.Synchronous)]
+[Step("Create", "account", "name,description,accountnumber", Stages.PostOperation, ExecutionMode.Synchronous)]
 public partial class AccountGreetingPlugin : IPlugin
 {
     [Dependency]

--- a/src/Testbed/Classic/ClassicPluginsCS13/AccountGreetingPlugin.g.cs
+++ b/src/Testbed/Classic/ClassicPluginsCS13/AccountGreetingPlugin.g.cs
@@ -27,6 +27,7 @@ namespace XrmGenTest
             scope.Set<IServiceProvider>(serviceProvider);
         
             scope.Set<IPluginExecutionContext>((IPluginExecutionContext)serviceProvider.GetService(typeof(IPluginExecutionContext)));
+            scope.Set<IOrganizationService>((IOrganizationService)serviceProvider.GetService(typeof(IOrganizationService)));
             return scope;
         }
     

--- a/src/Testbed/Classic/ClassicPluginsCS13/ClassicPluginsCS13.csproj
+++ b/src/Testbed/Classic/ClassicPluginsCS13/ClassicPluginsCS13.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AccountGreetingPlugin.cs">
-      <Generator>Xrm Tools Plugin Code Generator</Generator>
+      <Generator>XrmTools Plugin Code Generator</Generator>
       <IsXrmPlugin>True</IsXrmPlugin>
       <LastGenOutput>AccountGreetingPlugin.g.cs</LastGenOutput>
     </Compile>
@@ -135,7 +135,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="XrmTools.Meta.Attributes">
-      <Version>1.1.2</Version>
+      <Version>1.1.4</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Tests/XrmTools.Core.Tests/XrmTools.Core.Tests.csproj
+++ b/src/Tests/XrmTools.Core.Tests/XrmTools.Core.Tests.csproj
@@ -13,12 +13,12 @@
     <None Remove="Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
-      <Version>8.9.0</Version>
+      <Version>8.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing">
       <Version>8.10.0</Version>

--- a/src/Tests/XrmTools.Meta.Attributes.NuGet/Consumer/Consumer.csproj
+++ b/src/Tests/XrmTools.Meta.Attributes.NuGet/Consumer/Consumer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+	<TargetFrameworks>net462;net48</TargetFrameworks>
+	<RestoreSources>$(XrmToolsMetaAttributesRestoreSources)</RestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<PackageReference Include="XrmTools.Meta.Attributes" Version="$(XrmToolsMetaAttributesPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Tests/XrmTools.Meta.Attributes.NuGet/Consumer/ConsumerPlugin.cs
+++ b/src/Tests/XrmTools.Meta.Attributes.NuGet/Consumer/ConsumerPlugin.cs
@@ -1,0 +1,8 @@
+using XrmTools.Meta.Attributes;
+
+namespace NuGetConsumer;
+
+[Plugin]
+public sealed class ConsumerPlugin
+{
+}

--- a/src/Tests/XrmTools.Meta.Attributes.NuGet/Inspector/Inspector.cs
+++ b/src/Tests/XrmTools.Meta.Attributes.NuGet/Inspector/Inspector.cs
@@ -1,0 +1,8 @@
+using XrmTools.Meta.Attributes;
+
+namespace NuGetInspector;
+
+public sealed class Inspector
+{
+    private readonly PluginAttribute _attribute = null;
+}

--- a/src/Tests/XrmTools.Meta.Attributes.NuGet/Inspector/Inspector.csproj
+++ b/src/Tests/XrmTools.Meta.Attributes.NuGet/Inspector/Inspector.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+	<TargetFrameworks>net462;net48</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<Reference Include="Consumer">
+	  <HintPath>..\Consumer\bin\Debug\$(TargetFramework)\Consumer.dll</HintPath>
+	  <Private>false</Private>
+	</Reference>
+  </ItemGroup>
+</Project>

--- a/src/Tests/XrmTools.Tests/XrmTools.Tests.csproj
+++ b/src/Tests/XrmTools.Tests/XrmTools.Tests.csproj
@@ -30,11 +30,11 @@
     <None Remove="Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
@@ -45,7 +45,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="PolySharp">
-      <Version>1.15.0</Version>
+      <Version>1.16.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -53,7 +53,7 @@
     <!-- VS2022 supports System.Threading.Tasks.Extensions supports 4.6.0-->
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" NoWarn="NU1605" />
 	<!-- VS2022 only supports System.Text.Json 9.0.0 -->
-	<PackageReference Include="System.Text.Json" Version="9.0.0" NoWarn="NU1605"/>
+	<PackageReference Include="System.Text.Json" Version="9.0.0" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\XrmTools.Core\XrmTools.Core.csproj">

--- a/src/Tests/XrmTools.WebApi.Tests/XrmTools.WebApi.Tests.csproj
+++ b/src/Tests/XrmTools.WebApi.Tests/XrmTools.WebApi.Tests.csproj
@@ -11,18 +11,18 @@
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PolySharp" Version="1.15.0">
+    <PackageReference Include="PolySharp" Version="1.16.0">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="FluentAssertions.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Scriban" Version="7.1.0" />
     <!-- VS2022 supports System.Text.Json supports 9.0.0-->
     <PackageReference Include="System.Text.Json" Version="9.0.0" NoWarn="NU1605" />

--- a/src/XrmTools.Core/XrmTools.Core.csproj
+++ b/src/XrmTools.Core/XrmTools.Core.csproj
@@ -25,28 +25,28 @@
 		</Compile>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="CredentialManagement" Version="1.0.2"/>
-		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0"/>
-		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1"/>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.79.2"/>
-		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.79.2"/>
-		<PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="17.14.275"/>
-		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265"/>
-		<PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="17.14.40264"/>
-		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15"/>
+		<PackageReference Include="CredentialManagement" Version="1.0.2" />
+		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.79.2" />
+		<PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="17.14.275" />
+		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
+		<PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="17.14.40264" />
+		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
 			<Version>17.14.15</Version>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-		<PackageReference Include="Polly" Version="8.6.5"/>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Polly" Version="8.6.5" />
 		<PackageReference Include="PolySharp">
-			<Version>1.15.0</Version>
+			<Version>1.16.0</Version>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="System.Runtime.Caching" Version="8.0.1"/>
+		<PackageReference Include="System.Runtime.Caching" Version="8.0.1" />
 		<PackageReference Include="System.Text.Json" Version="9.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj
+++ b/src/XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.Build.NoTargets/2.0.1" DefaultTargets="Pack">
+  <PropertyGroup>
+	<TargetFramework>netstandard2.0</TargetFramework>
+	<NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+	<Title>XrmTools.Meta.Attributes</Title>
+	<Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
+	<PackageId>XrmTools.Meta.Attributes</PackageId>
+	<VersionPrefix>1.1.4</VersionPrefix>
+	<Authors>Reza Niroomand</Authors>
+	<PackageIcon>XrmTools_256.png</PackageIcon>
+	<PackageTags>Power Platform Apps XRM Tools</PackageTags>
+	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
+	<RepositoryUrl>https://github.com/rezanid/xrmtools</RepositoryUrl>
+	<DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="..\XrmTools.Meta.Attributes.SourceGenerator\XrmTools.Meta.Attributes.SourceGenerator.csproj" ReferenceOutputAssembly="false" />
+	<ProjectReference Include="..\Analyzers\XrmTools.Analyzers\XrmTools.Analyzers.csproj" ReferenceOutputAssembly="false" />
+	<ProjectReference Include="..\Analyzers\XrmTools.Analyzers.CodeFixes\XrmTools.Analyzers.CodeFixes.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<None Include="..\XrmTools.Meta.Attributes\README.md" PackagePath="\" Pack="true" />
+	<None Include="..\XrmTools.Meta.Attributes\images\XrmTools_256.png" PackagePath="\" Pack="true" />
+	<None Include="..\XrmTools.Meta.Attributes\build\XrmTools.Meta.Attributes.targets" PackagePath="build\" Pack="true" />
+	<None Include="..\XrmTools.Meta.Attributes\build\XrmTools.Meta.Attributes.targets" PackagePath="buildTransitive\" Pack="true" />
+	<None Include="..\XrmTools.Meta.Attributes\schemas\*.xsd" PackagePath="build\schemas\" Pack="true" />
+	<None Include="..\XrmTools.Meta.Attributes\tools\*.ps1" PackagePath="tools\" Pack="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<None Include="..\XrmTools.Meta.Attributes.SourceGenerator\bin\$(Configuration)\netstandard2.0\XrmTools.Meta.Attributes.SourceGenerator.dll" PackagePath="analyzers\dotnet\cs" Pack="true" />
+	<None Include="..\Analyzers\XrmTools.Analyzers\bin\$(Configuration)\netstandard2.0\XrmTools.Analyzers.dll" PackagePath="analyzers\dotnet\cs" Pack="true" />
+	<None Include="..\Analyzers\XrmTools.Analyzers.CodeFixes\bin\$(Configuration)\netstandard2.0\XrmTools.Analyzers.CodeFixes.dll" PackagePath="analyzers\dotnet\cs" Pack="true" />
+  </ItemGroup>
+</Project>

--- a/src/XrmTools.Meta.Attributes.SourceGenerator/MetaAttributesSourceGenerator.cs
+++ b/src/XrmTools.Meta.Attributes.SourceGenerator/MetaAttributesSourceGenerator.cs
@@ -1,0 +1,186 @@
+#nullable enable
+namespace XrmTools.Meta.Attributes.SourceGenerator;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+[Generator(LanguageNames.CSharp)]
+public sealed class MetaAttributesSourceGenerator : IIncrementalGenerator
+{
+    private const string UsePublicAccessibilityPropertyName = "build_property.XrmToolsMetaAttributesUsePublicAccessibility";
+    private const string ResourcePrefix = "XrmTools.Meta.Attributes.Sources.";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        IncrementalValueProvider<bool> usePublicAccessibility = context.AnalyzerConfigOptionsProvider
+            .Select((options, _) => UsePublicAccessibility(options.GlobalOptions));
+
+        IncrementalValueProvider<GeneratorOptions> options = context.CompilationProvider
+            .Combine(usePublicAccessibility)
+            .Select((pair, _) => new GeneratorOptions(pair.Right, ShouldEmitDependencyScope(pair.Left)));
+
+        IncrementalValueProvider<ImmutableArray<EmbeddedSourceFile>> sourceFiles = options
+            .Select((generatorOptions, _) => LoadEmbeddedSources(generatorOptions));
+
+        context.RegisterSourceOutput(sourceFiles, static (productionContext, sources) =>
+        {
+            foreach (EmbeddedSourceFile source in sources)
+            {
+                productionContext.AddSource(source.HintName, source.Content);
+            }
+        });
+    }
+
+    private static bool UsePublicAccessibility(AnalyzerConfigOptions globalOptions)
+    {
+        if (!globalOptions.TryGetValue(UsePublicAccessibilityPropertyName, out string? value))
+        {
+            return false;
+        }
+
+        return bool.TryParse(value, out bool usePublicAccessibility) && usePublicAccessibility;
+    }
+
+    private static bool ShouldEmitDependencyScope(Compilation compilation)
+        => compilation.GetTypeByMetadataName("Microsoft.Xrm.Sdk.IPlugin") is not null;
+
+    private static ImmutableArray<EmbeddedSourceFile> LoadEmbeddedSources(GeneratorOptions options)
+    {
+        System.Reflection.Assembly assembly = typeof(MetaAttributesSourceGenerator).Assembly;
+
+        IEnumerable<string> resourceNames = assembly.GetManifestResourceNames()
+            .Where(static name => name.StartsWith(ResourcePrefix, StringComparison.Ordinal) && name.EndsWith(".cs", StringComparison.Ordinal))
+            .OrderBy(static name => name, StringComparer.Ordinal);
+
+        ImmutableArray<EmbeddedSourceFile>.Builder builder = ImmutableArray.CreateBuilder<EmbeddedSourceFile>();
+
+        foreach (string resourceName in resourceNames)
+        {
+            if (!options.EmitDependencyScope && resourceName.EndsWith("DependencyScope.cs", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            using Stream? stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream is null)
+            {
+                continue;
+            }
+
+            using StreamReader reader = new(stream);
+            string content = reader.ReadToEnd();
+            builder.Add(new EmbeddedSourceFile(CreateHintName(resourceName), RewriteAccessibility(content, options.UsePublicAccessibility)));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static string RewriteAccessibility(string content, bool usePublicAccessibility)
+    {
+        if (!usePublicAccessibility)
+        {
+            return content;
+        }
+
+        SyntaxNode root = CSharpSyntaxTree.ParseText(content).GetRoot();
+        SyntaxNode rewrittenRoot = new AccessibilityRewriter().Visit(root);
+
+        return rewrittenRoot.ToFullString();
+    }
+
+    private static string CreateHintName(string resourceName)
+    {
+        string relativeName = resourceName.Substring(ResourcePrefix.Length);
+        return relativeName.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_');
+    }
+
+    private sealed class AccessibilityRewriter : CSharpSyntaxRewriter
+    {
+        private int typeDepth;
+
+        public override SyntaxNode? VisitClassDeclaration(ClassDeclarationSyntax node)
+            => RewriteType(node, static (currentNode, modifiers) => currentNode.WithModifiers(modifiers));
+
+        public override SyntaxNode? VisitRecordDeclaration(RecordDeclarationSyntax node)
+            => RewriteType(node, static (currentNode, modifiers) => currentNode.WithModifiers(modifiers));
+
+        public override SyntaxNode? VisitStructDeclaration(StructDeclarationSyntax node)
+            => RewriteType(node, static (currentNode, modifiers) => currentNode.WithModifiers(modifiers));
+
+        public override SyntaxNode? VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+            => RewriteType(node, static (currentNode, modifiers) => currentNode.WithModifiers(modifiers));
+
+        public override SyntaxNode? VisitEnumDeclaration(EnumDeclarationSyntax node)
+            => RewriteType(node, static (currentNode, modifiers) => currentNode.WithModifiers(modifiers));
+
+        public override SyntaxNode? VisitDelegateDeclaration(DelegateDeclarationSyntax node)
+        {
+            if (typeDepth != 0)
+            {
+                return base.VisitDelegateDeclaration(node);
+            }
+
+            return base.VisitDelegateDeclaration(node.WithModifiers(RewriteModifiers(node.Modifiers)));
+        }
+
+        private TNode RewriteType<TNode>(TNode node, Func<TNode, SyntaxTokenList, TNode> update) where TNode : BaseTypeDeclarationSyntax
+        {
+            bool isTopLevelType = typeDepth == 0;
+            TNode currentNode = isTopLevelType ? update(node, RewriteModifiers(node.Modifiers)) : node;
+
+            typeDepth++;
+
+            SyntaxNode? visitedNode = base.Visit(currentNode);
+
+            typeDepth--;
+
+            return (TNode)visitedNode!;
+        }
+
+        private static SyntaxTokenList RewriteModifiers(SyntaxTokenList modifiers)
+        {
+            int internalIndex = modifiers.IndexOf(SyntaxKind.InternalKeyword);
+            if (internalIndex < 0)
+            {
+                return modifiers;
+            }
+
+            SyntaxToken publicToken = SyntaxFactory.Token(modifiers[internalIndex].LeadingTrivia, SyntaxKind.PublicKeyword, modifiers[internalIndex].TrailingTrivia);
+
+            return modifiers.Replace(modifiers[internalIndex], publicToken);
+        }
+    }
+
+    private readonly struct EmbeddedSourceFile
+    {
+        public EmbeddedSourceFile(string hintName, string content)
+        {
+            HintName = hintName;
+            Content = content;
+        }
+
+        public string HintName { get; }
+
+        public string Content { get; }
+    }
+
+    private readonly struct GeneratorOptions
+    {
+        public GeneratorOptions(bool usePublicAccessibility, bool emitDependencyScope)
+        {
+            UsePublicAccessibility = usePublicAccessibility;
+            EmitDependencyScope = emitDependencyScope;
+        }
+
+        public bool UsePublicAccessibility { get; }
+
+        public bool EmitDependencyScope { get; }
+    }
+}

--- a/src/XrmTools.Meta.Attributes.SourceGenerator/XrmTools.Meta.Attributes.SourceGenerator.csproj
+++ b/src/XrmTools.Meta.Attributes.SourceGenerator/XrmTools.Meta.Attributes.SourceGenerator.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+	<TargetFramework>netstandard2.0</TargetFramework>
+	<ImplicitUsings>disable</ImplicitUsings>
+	<Nullable>enable</Nullable>
+	<IsPackable>false</IsPackable>
+	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+	<RootNamespace>XrmTools.Meta.Attributes.SourceGenerator</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<EmbeddedResource Include="..\XrmTools.Meta.Attributes\src\**\*.cs">
+	  <LogicalName>XrmTools.Meta.Attributes.Sources/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+	</EmbeddedResource>
+  </ItemGroup>
+</Project>

--- a/src/XrmTools.Meta.Attributes.SourceGenerator/XrmToolsMetaAttributesGenerator.cs
+++ b/src/XrmTools.Meta.Attributes.SourceGenerator/XrmToolsMetaAttributesGenerator.cs
@@ -1,0 +1,186 @@
+#nullable enable
+namespace XrmTools.Meta.Attributes.SourceGenerator;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+[Generator(LanguageNames.CSharp)]
+public sealed class XrmToolsMetaAttributesGenerator : IIncrementalGenerator
+{
+    private const string ResourcePrefix = "XrmTools.Meta.Attributes.Sources/";
+    private const string UsePublicAccessibilityPropertyName = "build_property.XrmToolsMetaAttributesUsePublicAccessibility";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var compilationAndOptions = context.CompilationProvider.Combine(context.AnalyzerConfigOptionsProvider);
+
+        context.RegisterSourceOutput(compilationAndOptions, static (sourceProductionContext, value) =>
+        {
+            var compilation = value.Left;
+            var options = GeneratorOptions.From(value.Right.GlobalOptions);
+
+            foreach (var sourceFile in GetSourceFiles(compilation, options))
+            {
+                sourceProductionContext.AddSource(sourceFile.HintName, sourceFile.Content);
+            }
+        });
+    }
+
+    private static IReadOnlyList<GeneratedSourceFile> GetSourceFiles(Compilation compilation, GeneratorOptions options)
+    {
+        var assembly = typeof(XrmToolsMetaAttributesGenerator).Assembly;
+        var names = assembly.GetManifestResourceNames()
+            .Where(static name => name.Replace('\\', '/').StartsWith(ResourcePrefix, StringComparison.Ordinal))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var files = new List<GeneratedSourceFile>(names.Length);
+        var hasXrmSdkReference = HasXrmSdkReference(compilation);
+
+        foreach (var name in names)
+        {
+            using var stream = assembly.GetManifestResourceStream(name);
+            if (stream is null)
+            {
+                continue;
+            }
+
+            using var reader = new StreamReader(stream, Encoding.UTF8, true);
+            var content = reader.ReadToEnd();
+            var normalizedName = name.Replace('\\', '/');
+            var relativePath = normalizedName.Substring(ResourcePrefix.Length);
+            if (!hasXrmSdkReference && string.Equals(relativePath, "DependencyScope.cs", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var emittedContent = options.UsePublicAccessibility
+                ? RewriteTopLevelAccessibility(content)
+                : content;
+
+            files.Add(new GeneratedSourceFile(relativePath.Replace('/', '_'), emittedContent));
+        }
+
+        return files;
+    }
+
+    private static bool HasXrmSdkReference(Compilation compilation)
+    {
+        foreach (var reference in compilation.ReferencedAssemblyNames)
+        {
+            if (string.Equals(reference.Name, "Microsoft.Xrm.Sdk", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string RewriteTopLevelAccessibility(string content)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(content);
+        var root = syntaxTree.GetRoot();
+        var rewrittenRoot = new TopLevelAccessibilityRewriter().Visit(root);
+
+        return rewrittenRoot?.ToFullString() ?? content;
+    }
+
+    private readonly struct GeneratorOptions
+    {
+        public GeneratorOptions(bool usePublicAccessibility)
+        {
+            UsePublicAccessibility = usePublicAccessibility;
+        }
+
+        public bool UsePublicAccessibility { get; }
+
+        public static GeneratorOptions From(AnalyzerConfigOptions options)
+        {
+            if (options.TryGetValue(UsePublicAccessibilityPropertyName, out var value))
+            {
+                if (bool.TryParse(value, out var usePublicAccessibility))
+                {
+                    return new GeneratorOptions(usePublicAccessibility);
+                }
+            }
+
+            return default;
+        }
+    }
+
+    private sealed class TopLevelAccessibilityRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode? VisitClassDeclaration(ClassDeclarationSyntax node) =>
+            base.VisitClassDeclaration(RewriteDeclaration(node, static (declaration, modifiers) => declaration.WithModifiers(modifiers)));
+
+        public override SyntaxNode? VisitEnumDeclaration(EnumDeclarationSyntax node) =>
+            base.VisitEnumDeclaration(RewriteDeclaration(node, static (declaration, modifiers) => declaration.WithModifiers(modifiers)));
+
+        public override SyntaxNode? VisitInterfaceDeclaration(InterfaceDeclarationSyntax node) =>
+            base.VisitInterfaceDeclaration(RewriteDeclaration(node, static (declaration, modifiers) => declaration.WithModifiers(modifiers)));
+
+        public override SyntaxNode? VisitRecordDeclaration(RecordDeclarationSyntax node) =>
+            base.VisitRecordDeclaration(RewriteDeclaration(node, static (declaration, modifiers) => declaration.WithModifiers(modifiers)));
+
+        public override SyntaxNode? VisitStructDeclaration(StructDeclarationSyntax node) =>
+            base.VisitStructDeclaration(RewriteDeclaration(node, static (declaration, modifiers) => declaration.WithModifiers(modifiers)));
+
+        private static T RewriteDeclaration<T>(T declaration, Func<T, SyntaxTokenList, T> updateModifiers)
+            where T : MemberDeclarationSyntax
+        {
+            if (!IsTopLevelDeclaration(declaration))
+            {
+                return declaration;
+            }
+
+            var modifiers = GetModifiers(declaration);
+            for (int i = 0; i < modifiers.Count; i++)
+            {
+                if (!modifiers[i].IsKind(SyntaxKind.InternalKeyword))
+                {
+                    continue;
+                }
+
+                modifiers = modifiers.Replace(modifiers[i], SyntaxFactory.Token(modifiers[i].LeadingTrivia, SyntaxKind.PublicKeyword, modifiers[i].TrailingTrivia));
+                return updateModifiers(declaration, modifiers);
+            }
+
+            return declaration;
+        }
+
+        private static SyntaxTokenList GetModifiers(MemberDeclarationSyntax declaration) => declaration switch
+        {
+            ClassDeclarationSyntax classDeclaration => classDeclaration.Modifiers,
+            EnumDeclarationSyntax enumDeclaration => enumDeclaration.Modifiers,
+            InterfaceDeclarationSyntax interfaceDeclaration => interfaceDeclaration.Modifiers,
+            RecordDeclarationSyntax recordDeclaration => recordDeclaration.Modifiers,
+            StructDeclarationSyntax structDeclaration => structDeclaration.Modifiers,
+            _ => default,
+        };
+
+        private static bool IsTopLevelDeclaration(MemberDeclarationSyntax declaration) =>
+            declaration.Parent is NamespaceDeclarationSyntax or FileScopedNamespaceDeclarationSyntax or CompilationUnitSyntax;
+    }
+
+    private readonly struct GeneratedSourceFile
+    {
+        public GeneratedSourceFile(string hintName, string content)
+        {
+            HintName = hintName;
+            Content = content;
+        }
+
+        public string HintName { get; }
+
+        public string Content { get; }
+    }
+}

--- a/src/XrmTools.Meta.Attributes/README.md
+++ b/src/XrmTools.Meta.Attributes/README.md
@@ -4,6 +4,20 @@ This package is part of the [Xrm Tools](https://marketplace.visualstudio.com/ite
 
 If you aren't already using [Xrm Tools](https://marketplace.visualstudio.com/items?itemName=rezanid.XrmTools) for Power Platform development, I suggest checking out [Xrm Tools Wiki](https://github.com/rezanid/xrmtools/wiki) to learn how modern way of Power Platform development can enhance your experience. You can do pretty much everything with regards to plugins and API development without ever leaving Visual Studio.
 
+## Accessibility
+
+By default, the types generated into your project from `XrmTools.Meta.Attributes` are `internal`.
+
+If you want the generated types to be `public`, add the following property to your consuming project:
+
+```xml
+<PropertyGroup>
+  <XrmToolsMetaAttributesUsePublicAccessibility>true</XrmToolsMetaAttributesUsePublicAccessibility>
+</PropertyGroup>
+```
+
+This switch is optional. The NuGet package name remains `XrmTools.Meta.Attributes`.
+
 ## Attributes
 
 By installing this nuget packge, you will be able to use attributes to decorate your Dataverse plugins with metadata to enable code generation and automatic registration. Supported attributes are:

--- a/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
+++ b/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
@@ -3,8 +3,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
     <Authors>Reza Niroomand</Authors>
     <PackageIcon>XrmTools_256.png</PackageIcon>
@@ -12,33 +13,12 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageTags>Power Platform Apps XRM Tools</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/rezanid/xrmtools</RepositoryUrl>
-
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
-  <!-- Pack the targets into /build (and optionally /buildTransitive) -->
-  <ItemGroup>
-    <None Include="build/XrmTools.Meta.Attributes.targets" Pack="true" PackagePath="build/" />
-    <!-- Optional: transitive import for PackageReference consumers -->
-    <!--<None Include="buildTransitive/XrmTools.Meta.Attributes.targets"
-          Pack="true" PackagePath="buildTransitive/" />-->
-  </ItemGroup>
-  <!-- Pack the source files  -->
-  <ItemGroup>
-    <None Include="src/**/*.cs" Pack="true" PackagePath="src/" />
-  </ItemGroup>
-  <!-- Readme & Icon -->
-  <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="/" />
-    <None Include="images/XrmTools_256.png" Pack="true" PackagePath="/" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="schemas\*.xsd" Pack="true" PackagePath="build/schemas/" />
-  </ItemGroup>
   <ItemGroup>
     <None Update="schemas\Fetch.xsd">
       <SubType>Designer</SubType>
@@ -51,13 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="tools\*.ps1" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="" />
+    <None Update="tools\*.ps1" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
-  <Target Name="_AddAnalyzersToOutput">
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\XrmTools.Analyzers.dll" PackagePath="analyzers/dotnet/cs" />
-      <TfmSpecificPackageFile Include="$(OutputPath)\XrmTools.Analyzers.CodeFixes.dll" PackagePath="analyzers/dotnet/cs" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/XrmTools.Meta.Attributes/build/XrmTools.Meta.Attributes.targets
+++ b/src/XrmTools.Meta.Attributes/build/XrmTools.Meta.Attributes.targets
@@ -1,27 +1,17 @@
 <Project>
-  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)../src')">
-    <Compile Include="$(MSBuildThisFileDirectory)../src/**/*.cs"
-             Visible="false" />
-  </ItemGroup>
-
-  <!-- Conditionally remove files if the consumer project doesn't reference Microsoft.Xrm.Sdk.dll -->
-  <Target Name="ExcludeXrmFilesIfNoReference" BeforeTargets="CoreCompile">
-    <ItemGroup>
-      <!-- Check for Microsoft.Xrm.Sdk.dll in resolved references -->
-      <_XrmReference Include="@(ReferencePath)" Condition=" '%(Filename)%(Extension)' == 'Microsoft.Xrm.Sdk.dll' " />
-    </ItemGroup>
-
-    <!-- If not found, exclude specific file(s) -->
-    <ItemGroup Condition="'@(_XrmReference)' == ''">
-      <Compile Remove="**/DependencyScope.cs" />
-    </ItemGroup>
-  </Target>
-
   <PropertyGroup>
+    <XrmToolsMetaAttributesUsePublicAccessibility Condition="'$(XrmToolsMetaAttributesUsePublicAccessibility)'==''">false</XrmToolsMetaAttributesUsePublicAccessibility>
     <!-- Allow override by the consumer if they want a different location or to disable the copy -->
     <XrmToolsSchemasDir Condition="'$(XrmToolsSchemasDir)'==''">$(MSBuildProjectDirectory)/.xrmtools/schemas/</XrmToolsSchemasDir>
     <XrmToolsCopySchemas Condition="'$(XrmToolsCopySchemas)'==''">true</XrmToolsCopySchemas>
   </PropertyGroup>
+
+  <Target Name="ConfigureXrmToolsMetaAttributes"
+          BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <CompilerVisibleProperty Include="XrmToolsMetaAttributesUsePublicAccessibility" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup Condition="'$(XrmToolsCopySchemas)'=='true'">
     <!-- Resolve the XSD(s) from the package’s build/schemas folder -->

--- a/src/XrmTools.Meta/XrmTools.Meta.csproj
+++ b/src/XrmTools.Meta/XrmTools.Meta.csproj
@@ -44,10 +44,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
+      <Version>13.0.4</Version>
     </PackageReference>
     <PackageReference Include="PolySharp">
-      <Version>1.15.0</Version>
+      <Version>1.16.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XrmTools.WebApi/XrmTools.WebApi.csproj
+++ b/src/XrmTools.WebApi/XrmTools.WebApi.csproj
@@ -20,6 +20,9 @@
   <PropertyGroup>
     <XrmToolsCopySchemas>false</XrmToolsCopySchemas>
   </PropertyGroup>
+  <PropertyGroup>
+    <XrmToolsMetaAttributesUsePublicAccessibility>true</XrmToolsMetaAttributesUsePublicAccessibility>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Methods\**" />
     <EmbeddedResource Remove="Methods\**" />
@@ -28,19 +31,18 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PolySharp" Version="1.15.0">
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
-    <PackageReference Include="XrmTools.Meta.Attributes" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XrmTools.Core\XrmTools.Core.csproj" />
+	<!-- Instead of referencing the NuGet package we reference the project directly and import the targets file-->
+    <ProjectReference Include="..\XrmTools.Meta.Attributes.SourceGenerator\XrmTools.Meta.Attributes.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Analyzers\XrmTools.Analyzers\XrmTools.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />
@@ -53,4 +55,5 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
+  <Import Project="..\XrmTools.Meta.Attributes\build\XrmTools.Meta.Attributes.targets" />
 </Project>

--- a/src/XrmTools.slnx
+++ b/src/XrmTools.slnx
@@ -44,6 +44,8 @@
   <Project Path="XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj" Type="13b669be-bb05-4ddf-9536-439f39a36129">
     <Platform Project="AnyCPU" />
   </Project>
+  <Project Path="XrmTools.Meta.Attributes.SourceGenerator/XrmTools.Meta.Attributes.SourceGenerator.csproj" />
+  <Project Path="XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129"/>
   <Project Path="XrmTools.Meta/XrmTools.Meta.csproj" />
   <Project Path="XrmTools.UI.Controls/XrmTools.UI.Controls.csproj" Id="179df0ac-6f44-4656-8332-034d3c594ed1" />
   <Project Path="XrmTools.WebApi/XrmTools.WebApi.csproj" />

--- a/src/XrmTools/XrmTools.csproj
+++ b/src/XrmTools/XrmTools.csproj
@@ -499,13 +499,13 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3856.49" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="NuGet.VisualStudio" Version="17.14.0" />
     <PackageReference Include="NuGet.VisualStudio.Contracts" Version="17.14.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="PolySharp">
-      <Version>1.15.0</Version>
+      <Version>1.16.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/src.slnx
+++ b/src/src.slnx
@@ -1,0 +1,1 @@
+<Solution />


### PR DESCRIPTION
- introduce source-generator based emission for XrmTools.Meta.Attributes
- keep generated types internal by default
- add XrmToolsMetaAttributesUsePublicAccessibility opt-in switch
- move DependencyScope generation behind Xrm SDK reference detection
- split packaging into dedicated XrmTools.Meta.Attributes.Package project
- update XrmTools.WebApi to consume public generated types
- add direct generator tests and NuGet consumption tests for net462/net48
- document the new accessibility switch