### PR TITLE
Add custom menu controls and styles for WPF shell

### DIFF
--- a/src/XrmTools/Shell/Controls/ContextMenu.cs
+++ b/src/XrmTools/Shell/Controls/ContextMenu.cs
@@ -1,0 +1,96 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System.Windows;
+using System.Windows.Input;
+using XrmTools.Shell.Helpers;
+
+public class ContextMenu : System.Windows.Controls.ContextMenu
+{
+    private static readonly DependencyPropertyKey IsClosedPropertyKey = Property.RegisterReadOnly<ContextMenu, bool>(nameof(IsClosed), true);
+    public static readonly DependencyProperty IsClosedProperty = IsClosedPropertyKey.DependencyProperty;
+    
+    internal static event RoutedEventHandler? ContextMenuOpened;
+
+    internal static event RoutedEventHandler? ContextMenuClosed;
+
+    static ContextMenu()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(ContextMenu), new FrameworkPropertyMetadata(typeof(ContextMenu)));
+    }
+
+    public bool IsClosed
+    {
+        get => (bool)this.GetValue(IsClosedProperty);
+        private set => this.SetValue(IsClosedPropertyKey, Boxes.Box<bool>(value));
+    }
+
+    protected override DependencyObject GetContainerForItemOverride()
+    {
+        return (DependencyObject)new MenuItem();
+    }
+
+    protected override bool IsItemItsOwnContainerOverride(object item)
+    {
+        return item is MenuItem || item is Separator;
+    }
+
+    protected override void OnClosed(RoutedEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine("OnClosed");
+        base.OnClosed(e);
+        this.IsClosed = true;
+        RoutedEventHandler contextMenuClosed = ContextMenuClosed;
+        if (contextMenuClosed == null)
+            return;
+        contextMenuClosed((object)this, e);
+    }
+
+    protected override void OnOpened(RoutedEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine("OnOpened");
+        base.OnOpened(e);
+        this.IsClosed = false;
+        RoutedEventHandler contextMenuOpened = ContextMenuOpened;
+        if (contextMenuOpened == null)
+            return;
+        contextMenuOpened((object)this, e);
+    }
+
+    protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine("OnPreviewMouseLeftButtonDown");
+        this.HandleAutoClose(e.OriginalSource);
+        base.OnPreviewMouseLeftButtonDown(e);
+    }
+
+    protected override void OnPreviewMouseRightButtonDown(MouseButtonEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine("OnPreviewMouseRightButtonDown");
+        this.HandleAutoClose(e.OriginalSource);
+        base.OnPreviewMouseRightButtonDown(e);
+    }
+
+    protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
+    {
+        object obj1 = (object)null;
+        object obj2 = (object)null;
+        Separator separator = element as Separator;
+        if (separator != null)
+        {
+            obj1 = separator.GetValue(FrameworkElement.DefaultStyleKeyProperty);
+            obj2 = separator.GetValue(FrameworkElement.StyleProperty);
+        }
+        base.PrepareContainerForItemOverride(element, item);
+        if (separator == null)
+            return;
+        separator.SetValue(FrameworkElement.DefaultStyleKeyProperty, obj1);
+        separator.SetValue(FrameworkElement.StyleProperty, obj2);
+    }
+
+    private void HandleAutoClose(object originalSource)
+    {
+        if (!(originalSource is PassThroughBorder))
+            return;
+        this.IsOpen = false;
+    }
+}

--- a/src/XrmTools/Shell/Controls/FlyoutSurface.cs
+++ b/src/XrmTools/Shell/Controls/FlyoutSurface.cs
@@ -1,0 +1,27 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System.Windows;
+using System.Windows.Controls;
+using XrmTools.Shell.Helpers;
+
+public class FlyoutSurface : ContentControl
+{
+    public static readonly double ControlMaxWidth = 660.0;
+    public static readonly double Offset = 2.0;
+    public static readonly double OffsetInvert = -FlyoutSurface.Offset;
+    public static readonly double ShadowSize = 12.0;
+    public static readonly Thickness ShadowMargin = new Thickness(FlyoutSurface.ShadowSize, FlyoutSurface.Offset, FlyoutSurface.ShadowSize, FlyoutSurface.ShadowSize);
+    public static readonly double HorizontalOffsetInvert = -FlyoutSurface.ShadowSize;
+    public static readonly double VerticalOffsetInvert = -FlyoutSurface.Offset;
+
+    static FlyoutSurface()
+    {
+        FrameworkElement.DefaultStyleKeyProperty.OverrideMetadata(typeof(FlyoutSurface), (PropertyMetadata)new FrameworkPropertyMetadata((object)typeof(FlyoutSurface)));
+    }
+
+    protected override Size MeasureOverride(Size constraint)
+    {
+        VisualTree.InvalidateMeasureToAncestor(this.Content as FrameworkElement, (FrameworkElement)this);
+        return base.MeasureOverride(constraint);
+    }
+}

--- a/src/XrmTools/Shell/Controls/MenuItem.cs
+++ b/src/XrmTools/Shell/Controls/MenuItem.cs
@@ -1,0 +1,189 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using XrmTools.Shell.Helpers;
+
+[TemplatePart(Name = "PART_Popup", Type = typeof(Popup))]
+public class MenuItem : System.Windows.Controls.MenuItem
+{
+    private const string PART_Popup = "PART_Popup";
+    public static readonly GridLength HeaderGestureSpaceGridLength = new GridLength(24.0);
+    public static readonly DependencyProperty GroupNameProperty = Property.Register<MenuItem, string>(nameof(GroupName));
+    public static readonly DependencyProperty IsSelectableProperty = Property.Register<MenuItem, bool>(nameof(IsSelectable), propertyChanged: new PropertyChangedCallback(MenuItem.IsSelectableChanged));
+    public new static readonly DependencyProperty IsSelectedProperty = Property.Register<MenuItem, bool>(nameof(IsSelected), propertyChanged: new PropertyChangedCallback(MenuItem.IsSelectedChanged));
+
+    static MenuItem()
+    {
+        FrameworkElement.DefaultStyleKeyProperty.OverrideMetadata(typeof(MenuItem), (PropertyMetadata)new FrameworkPropertyMetadata((object)typeof(MenuItem)));
+    }
+
+    public string GroupName
+    {
+        get => (string)this.GetValue(MenuItem.GroupNameProperty);
+        set => this.SetValue(MenuItem.GroupNameProperty, (object)value);
+    }
+
+    public bool IsSelectable
+    {
+        get => (bool)this.GetValue(MenuItem.IsSelectableProperty);
+        set => this.SetValue(MenuItem.IsSelectableProperty, Boxes.Box<bool>(value));
+    }
+
+    private static void IsSelectableChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (!(d is MenuItem menuItem) || !(e.NewValue is bool newValue) || newValue)
+            return;
+        menuItem.IsSelected = false;
+    }
+
+    public new bool IsSelected
+    {
+        get => this.IsSelectable && (bool)this.GetValue(MenuItem.IsSelectedProperty);
+        set => this.SetValue(MenuItem.IsSelectedProperty, Boxes.Box<bool>(value));
+    }
+
+    private static void IsSelectedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (e.OldValue == e.NewValue || !(d is MenuItem menuItem1))
+            return;
+        MenuItem.MenuItemAutomationPeer.RaiseIsSelectedAutomationEvent(menuItem1, (bool)e.OldValue, (bool)e.NewValue);
+        if (e.NewValue is bool newValue && !newValue || !(menuItem1.Parent is FrameworkElement parent))
+            return;
+        foreach (FrameworkElement child in LogicalTreeHelper.GetChildren(parent))
+        {
+            if (child is MenuItem menuItem2 && menuItem2 != menuItem1 && menuItem2.IsSelectable && !(menuItem2.GroupName != menuItem1.GroupName))
+                menuItem2.IsSelected = false;
+        }
+    }
+
+    protected override DependencyObject GetContainerForItemOverride()
+    {
+        return (DependencyObject)new MenuItem();
+    }
+
+    protected override bool IsItemItsOwnContainerOverride(object item)
+    {
+        return item is MenuItem || item is Separator;
+    }
+
+    public override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+        if (!(this.GetTemplateChild("PART_Popup") is Popup templateChild))
+            return;
+        templateChild.Placement = PlacementMode.Custom;
+        templateChild.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(this.PlacementCallback);
+    }
+
+    protected override void OnClick()
+    {
+        if (this.IsSelectable)
+            this.IsSelected = true;
+        base.OnClick();
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return (AutomationPeer)new MenuItem.MenuItemAutomationPeer((System.Windows.Controls.MenuItem)this);
+    }
+
+    protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
+    {
+        object obj1 = null;
+        object obj2 = null;
+        Separator separator = element as Separator;
+        if (separator != null)
+        {
+            obj1 = separator.GetValue(FrameworkElement.DefaultStyleKeyProperty);
+            obj2 = separator.GetValue(FrameworkElement.StyleProperty);
+        }
+        base.PrepareContainerForItemOverride(element, item);
+        if (separator == null)
+            return;
+        separator.SetValue(FrameworkElement.DefaultStyleKeyProperty, obj1);
+        separator.SetValue(FrameworkElement.StyleProperty, obj2);
+    }
+
+    private CustomPopupPlacement[] PlacementCallback(Size popupSize, Size targetSize, Point offset)
+    {
+        Point point1 = new Point(0.0, targetSize.Height);
+        Point point2 = new Point(2.0 * FlyoutSurface.ShadowSize - popupSize.Width, 0.0);
+        Point point3 = new Point(targetSize.Width, 0.0);
+        Point point4 = new Point(0.0, FlyoutSurface.ShadowSize - FlyoutSurface.Offset - popupSize.Height);
+        switch (this.Role)
+        {
+            case MenuItemRole.TopLevelItem:
+            case MenuItemRole.TopLevelHeader:
+                return new CustomPopupPlacement[2]
+                {
+          new CustomPopupPlacement(point1, PopupPrimaryAxis.None),
+          new CustomPopupPlacement(point4, PopupPrimaryAxis.None)
+                };
+            case MenuItemRole.SubmenuItem:
+            case MenuItemRole.SubmenuHeader:
+                return new CustomPopupPlacement[2]
+                {
+          new CustomPopupPlacement(point3, PopupPrimaryAxis.None),
+          new CustomPopupPlacement(point2, PopupPrimaryAxis.None)
+                };
+            default:
+                throw new NotSupportedException(this.Role.ToString());
+        }
+    }
+
+    private class MenuItemAutomationPeer(System.Windows.Controls.MenuItem owner) :
+      System.Windows.Automation.Peers.MenuItemAutomationPeer(owner),
+      ISelectionItemProvider
+    {
+        public bool IsSelected => ((MenuItem)this.Owner).IsSelected;
+
+        public IRawElementProviderSimple? SelectionContainer => (IRawElementProviderSimple)null;
+
+        public void AddToSelection()
+        {
+            if (!this.IsSelected)
+                throw new InvalidOperationException();
+        }
+
+        public override object? GetPattern(PatternInterface patternInterface)
+        {
+            if (((MenuItem)this.Owner).IsSelectable)
+            {
+                if (patternInterface == PatternInterface.SelectionItem)
+                    return (object)this;
+                if (patternInterface == PatternInterface.Toggle)
+                    return (object)null;
+            }
+            return base.GetPattern(patternInterface);
+        }
+
+        public void RemoveFromSelection()
+        {
+            if (this.IsSelected)
+                throw new InvalidOperationException();
+        }
+
+        public void Select()
+        {
+            if (!this.IsEnabled())
+                throw new ElementNotEnabledException();
+            if (!((MenuItem)this.Owner).IsSelectable)
+                throw new InvalidOperationException();
+            ((MenuItem)this.Owner).IsSelected = true;
+        }
+
+        internal static void RaiseIsSelectedAutomationEvent(
+          MenuItem menuItem,
+          bool oldValue,
+          bool newValue)
+        {
+            UIElementAutomationPeer.FromElement((UIElement)menuItem)?.RaisePropertyChangedEvent(SelectionItemPattern.IsSelectedProperty, (object)oldValue, (object)newValue);
+        }
+    }
+}

--- a/src/XrmTools/Shell/Controls/MenuScrollViewer.cs
+++ b/src/XrmTools/Shell/Controls/MenuScrollViewer.cs
@@ -1,0 +1,18 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System.Windows;
+using XrmTools.Shell.Helpers;
+
+public class MenuScrollViewer : System.Windows.Controls.ScrollViewer
+{
+    static MenuScrollViewer()
+    {
+        FrameworkElement.DefaultStyleKeyProperty.OverrideMetadata(typeof(MenuScrollViewer), (PropertyMetadata)new FrameworkPropertyMetadata((object)typeof(MenuScrollViewer)));
+    }
+
+    protected override Size MeasureOverride(Size constraint)
+    {
+        VisualTree.InvalidateMeasureToAncestor(this.Content as FrameworkElement, (FrameworkElement)this);
+        return base.MeasureOverride(constraint);
+    }
+}

--- a/src/XrmTools/Shell/Controls/PassThroughBorder.cs
+++ b/src/XrmTools/Shell/Controls/PassThroughBorder.cs
@@ -1,0 +1,17 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+internal class PassThroughBorder : Border
+{
+    public PassThroughBorder() => this.Background = (Brush)Brushes.Transparent;
+
+    protected override HitTestResult HitTestCore(PointHitTestParameters hitTestParameters)
+    {
+        if (Mouse.PrimaryDevice.LeftButton == MouseButtonState.Pressed)
+            return (HitTestResult)new PointHitTestResult((Visual)null, hitTestParameters.HitPoint);
+        return Mouse.PrimaryDevice.RightButton == MouseButtonState.Pressed ? (HitTestResult)new PointHitTestResult((Visual)null, hitTestParameters.HitPoint) : base.HitTestCore(hitTestParameters);
+    }
+}

--- a/src/XrmTools/Shell/Controls/Popup.cs
+++ b/src/XrmTools/Shell/Controls/Popup.cs
@@ -1,0 +1,144 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+using XrmTools.Shell.Helpers;
+using XrmTools.Shell.Styles;
+using XrmTools.Shell.Converters;
+
+[System.Windows.Markup.ContentProperty("Content")]
+public class Popup : System.Windows.Controls.Primitives.Popup
+{
+    private Popup.MenuModeScope? menuModeScope;
+    public static readonly DependencyProperty ContentProperty = Property.RegisterFull<Popup, object>(nameof(Content));
+    public static readonly DependencyProperty EnableMenuModeProperty = Property.Register<Popup, bool>(nameof(EnableMenuMode));
+    public static readonly DependencyProperty FocusOnOpenProperty = Property.Register<Popup, bool>(nameof(FocusOnOpen));
+    private static readonly DependencyPropertyKey IsClosedPropertyKey = Property.RegisterReadOnly<Popup, bool>(nameof(IsClosed), true);
+    public static readonly DependencyProperty IsClosedProperty = Popup.IsClosedPropertyKey.DependencyProperty;
+
+    static Popup()
+    {
+        FrameworkElement.DefaultStyleKeyProperty.OverrideMetadata(typeof(Popup), (PropertyMetadata)new FrameworkPropertyMetadata((object)typeof(Popup)));
+    }
+
+    public Popup()
+    {
+        this.Child = (UIElement)new FlyoutSurface();
+        BindingOperations.SetBinding((DependencyObject)this.Child, ContentControl.ContentProperty, (BindingBase)new Binding(nameof(Content))
+        {
+            Source = (object)this
+        });
+        BindingOperations.SetBinding((DependencyObject)this.Child, FrameworkElement.MinHeightProperty, (BindingBase)new Binding("MinHeight")
+        {
+            Source = (object)this
+        });
+        BindingOperations.SetBinding((DependencyObject)this.Child, FrameworkElement.MinWidthProperty, (BindingBase)new Binding("MinWidth")
+        {
+            Source = (object)this
+        });
+    }
+
+    public object Content
+    {
+        get => this.GetValue(Popup.ContentProperty);
+        set => this.SetValue(Popup.ContentProperty, value);
+    }
+
+    public bool EnableMenuMode
+    {
+        get => (bool)this.GetValue(Popup.EnableMenuModeProperty);
+        set => this.SetValue(Popup.EnableMenuModeProperty, Boxes.Box<bool>(value));
+    }
+
+    public bool FocusOnOpen
+    {
+        get => (bool)this.GetValue(Popup.FocusOnOpenProperty);
+        set => this.SetValue(Popup.FocusOnOpenProperty, Boxes.Box<bool>(value));
+    }
+
+    public bool IsClosed
+    {
+        get => (bool)this.GetValue(Popup.IsClosedProperty);
+        private set => this.SetValue(Popup.IsClosedPropertyKey, Boxes.Box<bool>(value));
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        this.IsClosed = true;
+        if (this.menuModeScope == null)
+            return;
+        this.menuModeScope.Dispose();
+        this.menuModeScope = (Popup.MenuModeScope)null;
+        if (!this.IsKeyboardFocusWithin)
+            return;
+        this.PlacementTarget?.Focus();
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == System.Windows.Input.Key.Escape)
+        {
+            this.IsOpen = false;
+            e.Handled = true;
+            this.PlacementTarget?.Focus();
+        }
+        else
+            base.OnKeyDown(e);
+    }
+
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+        this.IsClosed = false;
+        if (this.EnableMenuMode && this.menuModeScope == null)
+            this.menuModeScope = new Popup.MenuModeScope(this.PlacementTarget);
+        RenderOptions.SetBitmapScalingMode((DependencyObject)this.Child, BitmapScalingModeConverter.GetBitmapScalingMode((Visual)this.Child));
+        if (!this.FocusOnOpen)
+            return;
+        this.Child.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+    }
+
+    protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        this.HandleAutoClose(e.OriginalSource);
+        base.OnPreviewMouseLeftButtonDown(e);
+    }
+
+    protected override void OnPreviewMouseRightButtonDown(MouseButtonEventArgs e)
+    {
+        this.HandleAutoClose(e.OriginalSource);
+        base.OnPreviewMouseRightButtonDown(e);
+    }
+
+    private void HandleAutoClose(object originalSource)
+    {
+        if (this.StaysOpen && !InputManager.Current.IsInMenuMode || !(originalSource is PassThroughBorder))
+            return;
+        this.IsOpen = false;
+    }
+
+    private class MenuModeScope : IDisposable
+    {
+        private PresentationSource? source;
+
+        public MenuModeScope(UIElement element)
+        {
+            this.source = PresentationSource.FromVisual((Visual)element);
+            if (this.source == null)
+                return;
+            InputManager.Current.PushMenuMode(this.source);
+        }
+
+        public void Dispose()
+        {
+            if (this.source != null)
+                InputManager.Current.PopMenuMode(this.source);
+            this.source = (PresentationSource)null;
+        }
+    }
+}

--- a/src/XrmTools/Shell/Controls/Separator.cs
+++ b/src/XrmTools/Shell/Controls/Separator.cs
@@ -1,0 +1,13 @@
+﻿namespace XrmTools.Shell.Controls;
+
+using System.Windows;
+
+public class Separator : System.Windows.Controls.Separator
+{
+    public static readonly double StrokeWidth = 1.0;
+
+    static Separator()
+    {
+        FrameworkElement.DefaultStyleKeyProperty.OverrideMetadata(typeof(Separator), (PropertyMetadata)new FrameworkPropertyMetadata((object)typeof(Separator)));
+    }
+}

--- a/src/XrmTools/Shell/Conveters/BitmapScalingModeConverter.cs
+++ b/src/XrmTools/Shell/Conveters/BitmapScalingModeConverter.cs
@@ -1,0 +1,29 @@
+﻿namespace XrmTools.Shell.Converters;
+
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Utilities;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+
+public class BitmapScalingModeConverter :
+  MultiValueConverter<FrameworkElement, object, BitmapScalingMode>
+{
+    protected override BitmapScalingMode Convert(
+      FrameworkElement element,
+      object trigger,
+      object parameter,
+      CultureInfo culture)
+    {
+        //return VisualOptions.Instance.GetBitmapScalingMode((Visual)element);
+        return GetBitmapScalingMode(element);
+    }
+    
+    public static BitmapScalingMode GetBitmapScalingMode(Visual visual)
+    {
+        if (visual == null)
+            return BitmapScalingMode.Unspecified;
+        double dpiX = visual.GetDpiX();
+        return dpiX < 96.0 ? BitmapScalingMode.LowQuality : (dpiX % 96.0 != 0.0 ? BitmapScalingMode.HighQuality : BitmapScalingMode.NearestNeighbor);
+    }
+}

--- a/src/XrmTools/Shell/Conveters/ClipConverter.cs
+++ b/src/XrmTools/Shell/Conveters/ClipConverter.cs
@@ -1,0 +1,63 @@
+﻿namespace XrmTools.Shell.Conveters;
+
+using Microsoft.VisualStudio.PlatformUI;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+
+internal class ClipConverter : MultiValueConverter<double, double, CornerRadius, Geometry>
+{
+    protected override Geometry Convert(
+      double width,
+      double height,
+      CornerRadius cornerRadius,
+      object parameter,
+      CultureInfo culture)
+    {
+        Geometry clipGeometry = this.GenerateClipGeometry(new Size(width, height), cornerRadius);
+        if (clipGeometry.CanFreeze)
+            clipGeometry.Freeze();
+        return clipGeometry;
+    }
+
+    private Geometry GenerateClipGeometry(Size size, CornerRadius cornerRadius)
+    {
+        Point point = new Point(cornerRadius.TopLeft, 0.0);
+        Point endPoint1 = new Point(size.Width - cornerRadius.TopRight, 0.0);
+        Point endPoint2 = new Point(size.Width, cornerRadius.TopRight);
+        Point endPoint3 = new Point(size.Width, size.Height - cornerRadius.BottomRight);
+        Point endPoint4 = new Point(size.Width - cornerRadius.BottomRight, size.Height);
+        Point endPoint5 = new Point(cornerRadius.BottomLeft, size.Height);
+        Point endPoint6 = new Point(0.0, size.Height - cornerRadius.BottomLeft);
+        Point endPoint7 = new Point(0.0, cornerRadius.TopLeft);
+        StreamGeometry clipGeometry = new StreamGeometry();
+        using (StreamGeometryContext context = clipGeometry.Open())
+        {
+            context.BeginFigure(point, true, true);
+            DrawLineTo(context, endPoint1);
+            DrawArcTo(context, endPoint2, cornerRadius.TopRight, SweepDirection.Clockwise);
+            DrawLineTo(context, endPoint3);
+            DrawArcTo(context, endPoint4, cornerRadius.BottomRight, SweepDirection.Clockwise);
+            DrawLineTo(context, endPoint5);
+            DrawArcTo(context, endPoint6, cornerRadius.BottomLeft, SweepDirection.Clockwise);
+            DrawLineTo(context, endPoint7);
+            DrawArcTo(context, point, cornerRadius.TopLeft, SweepDirection.Clockwise);
+            clipGeometry.Freeze();
+        }
+        return (Geometry)clipGeometry;
+
+        static void DrawArcTo(
+          StreamGeometryContext context,
+          Point endPoint,
+          double radius,
+          SweepDirection direction)
+        {
+            context.ArcTo(endPoint, new Size(radius, radius), 0.0, false, direction, true, false);
+        }
+
+        static void DrawLineTo(StreamGeometryContext context, Point endPoint)
+        {
+            context.LineTo(endPoint, true, false);
+        }
+    }
+}

--- a/src/XrmTools/Shell/Conveters/ColorOpacityConverter.cs
+++ b/src/XrmTools/Shell/Conveters/ColorOpacityConverter.cs
@@ -1,0 +1,26 @@
+﻿namespace XrmTools.Shell.Conveters;
+
+using Microsoft.VisualStudio.PlatformUI;
+using System.Globalization;
+using System.Windows.Media;
+
+public class ColorOpacityConverter : ValueConverter<object, double>
+{
+    protected override double Convert(object value, object parameter, CultureInfo culture)
+    {
+        double num;
+        switch (value)
+        {
+            case Color color:
+                num = (double)color.A / (double)byte.MaxValue;
+                break;
+            case SolidColorBrush solidColorBrush:
+                num = (double)solidColorBrush.Color.A / (double)byte.MaxValue;
+                break;
+            default:
+                num = 1.0;
+                break;
+        }
+        return num;
+    }
+}

--- a/src/XrmTools/Shell/Conveters/Converters.cs
+++ b/src/XrmTools/Shell/Conveters/Converters.cs
@@ -1,8 +1,12 @@
 ﻿namespace XrmTools.Shell.Converters;
 
 using Microsoft.VisualStudio.PlatformUI;
+using XrmTools.Shell.Conveters;
 
 public static class Converters
 {
     public static readonly object MultiplyConverter = new MultiplyingConverter();
+    public static readonly object BitmapScalingModeConverter = new BitmapScalingModeConverter();
+    public static readonly object ClipConverter = new Styles.ClipConverter();
+    public static readonly object ColorOpacityConverter = new ColorOpacityConverter();
 }

--- a/src/XrmTools/Shell/Helpers/VisualTree.cs
+++ b/src/XrmTools/Shell/Helpers/VisualTree.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+namespace XrmTools.Shell.Helpers;
+
+using System.Windows;
+using System.Windows.Media;
+
+internal static class VisualTree
+{
+    public static void InvalidateMeasureToAncestor(
+      FrameworkElement? descendant,
+      FrameworkElement? ancestor)
+    {
+        if (descendant == ancestor)
+            return;
+        FrameworkElement reference = descendant;
+        while (reference != null)
+        {
+            reference.InvalidateMeasure();
+            reference = VisualTreeHelper.GetParent((DependencyObject)reference) as FrameworkElement;
+            if (reference == ancestor)
+                break;
+        }
+    }
+}
+

--- a/src/XrmTools/Shell/Styles/ClipConverter.cs
+++ b/src/XrmTools/Shell/Styles/ClipConverter.cs
@@ -1,0 +1,63 @@
+﻿namespace XrmTools.Shell.Styles;
+
+using Microsoft.VisualStudio.PlatformUI;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+
+internal class ClipConverter : MultiValueConverter<double, double, CornerRadius, Geometry>
+{
+    protected override Geometry Convert(
+      double width,
+      double height,
+      CornerRadius cornerRadius,
+      object parameter,
+      CultureInfo culture)
+    {
+        Geometry clipGeometry = this.GenerateClipGeometry(new Size(width, height), cornerRadius);
+        if (clipGeometry.CanFreeze)
+            clipGeometry.Freeze();
+        return clipGeometry;
+    }
+
+    private Geometry GenerateClipGeometry(Size size, CornerRadius cornerRadius)
+    {
+        Point point = new Point(cornerRadius.TopLeft, 0.0);
+        Point endPoint1 = new Point(size.Width - cornerRadius.TopRight, 0.0);
+        Point endPoint2 = new Point(size.Width, cornerRadius.TopRight);
+        Point endPoint3 = new Point(size.Width, size.Height - cornerRadius.BottomRight);
+        Point endPoint4 = new Point(size.Width - cornerRadius.BottomRight, size.Height);
+        Point endPoint5 = new Point(cornerRadius.BottomLeft, size.Height);
+        Point endPoint6 = new Point(0.0, size.Height - cornerRadius.BottomLeft);
+        Point endPoint7 = new Point(0.0, cornerRadius.TopLeft);
+        StreamGeometry clipGeometry = new StreamGeometry();
+        using (StreamGeometryContext context = clipGeometry.Open())
+        {
+            context.BeginFigure(point, true, true);
+            DrawLineTo(context, endPoint1);
+            DrawArcTo(context, endPoint2, cornerRadius.TopRight, SweepDirection.Clockwise);
+            DrawLineTo(context, endPoint3);
+            DrawArcTo(context, endPoint4, cornerRadius.BottomRight, SweepDirection.Clockwise);
+            DrawLineTo(context, endPoint5);
+            DrawArcTo(context, endPoint6, cornerRadius.BottomLeft, SweepDirection.Clockwise);
+            DrawLineTo(context, endPoint7);
+            DrawArcTo(context, point, cornerRadius.TopLeft, SweepDirection.Clockwise);
+            clipGeometry.Freeze();
+        }
+        return (Geometry)clipGeometry;
+
+        static void DrawArcTo(
+          StreamGeometryContext context,
+          Point endPoint,
+          double radius,
+          SweepDirection direction)
+        {
+            context.ArcTo(endPoint, new Size(radius, radius), 0.0, false, direction, true, false);
+        }
+
+        static void DrawLineTo(StreamGeometryContext context, Point endPoint)
+        {
+            context.LineTo(endPoint, true, false);
+        }
+    }
+}

--- a/src/XrmTools/Shell/Styles/ContextMenuStyle.xaml
+++ b/src/XrmTools/Shell/Styles/ContextMenuStyle.xaml
@@ -1,0 +1,49 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:cvrts="clr-namespace:XrmTools.Shell.Converters"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <Style TargetType="{x:Type ctrls:ContextMenu}">
+        <Setter Property="FrameworkElement.FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="ContextMenu.HorizontalOffset"
+            Value="{x:Static ctrls:FlyoutSurface.HorizontalOffsetInvert}"/>
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
+        <Setter Property="UIElement.SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="FrameworkElement.UseLayoutRounding" Value="True"/>
+        <Setter Property="ContextMenu.VerticalOffset" Value="{x:Static ctrls:FlyoutSurface.VerticalOffsetInvert}"/>
+        <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True"/>
+        <Setter Property="VirtualizingPanel.ScrollUnit" Value="Pixel"/>
+        <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Standard"/>
+        <Setter Property="ItemsControl.ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
+                                  VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}"/>
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="RenderOptions.BitmapScalingMode">
+            <Setter.Value>
+                <MultiBinding Converter="{x:Static cvrts:Converters.BitmapScalingModeConverter}">
+                    <Binding RelativeSource="{RelativeSource Self}"/>
+                    <Binding Path="IsOpen" RelativeSource="{RelativeSource Self}"/>
+                </MultiBinding>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ctrls:ContextMenu}">
+                    <ctrls:FlyoutSurface>
+                        <ctrls:MenuScrollViewer x:Name="PART_ScrollViewer" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}">
+                            <ItemsPresenter Grid.IsSharedSizeScope="True" KeyboardNavigation.DirectionalNavigation="Cycle"
+                              Margin="{x:Static styles:Spacings.XSNudge}"
+                              SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}"
+                              MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource TemplatedParent}}"/>
+                        </ctrls:MenuScrollViewer>
+                    </ctrls:FlyoutSurface>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/DefaultStyles.cs
+++ b/src/XrmTools/Shell/Styles/DefaultStyles.cs
@@ -43,10 +43,10 @@ internal static class DefaultStyles
         //  (object) typeof (ComboBoxItem),
         //  "/XrmTools;component/Shell/Styles/ComboBoxItemStyle.xaml"
         //},
-        //{
-        //  (object) typeof (ContextMenu),
-        //  "/XrmTools;component/Shell/Styles/ContextMenuStyle.xaml"
-        //},
+        {
+          (object) typeof (ContextMenu),
+          "/XrmTools;component/Shell/Styles/ContextMenuStyle.xaml"
+        },
         //{
         //  (object) typeof (DataGrid),
         //  "/XrmTools;component/Shell/Styles/DataGrid/DataGridStyle.xaml"
@@ -103,10 +103,10 @@ internal static class DefaultStyles
         //  (object) typeof (FeedbackPanel),
         //  "/XrmTools;component/Shell/Styles/FeedbackPanelStyle.xaml"
         //},
-        //{
-        //  (object) typeof (FlyoutSurface),
-        //  "/XrmTools;component/Shell/Styles/FlyoutSurfaceStyle.xaml"
-        //},
+        {
+          (object) typeof (FlyoutSurface),
+          "/XrmTools;component/Shell/Styles/FlyoutSurfaceStyle.xaml"
+        },
         //{
         //  (object) typeof (Heading),
         //  "/XrmTools;component/Shell/Styles/MarkdownViewer/HeadingStyle.xaml"
@@ -155,14 +155,14 @@ internal static class DefaultStyles
         //  (object) typeof (MediaHost),
         //  "/XrmTools;component/Shell/Styles/MarkdownViewer/MediaHostStyle.xaml"
         //},
-        //{
-        //  (object) typeof (MenuItem),
-        //  "/XrmTools;component/Shell/Styles/MenuItemStyle.xaml"
-        //},
-        //{
-        //  (object) typeof (MenuScrollViewer),
-        //  "/XrmTools;component/Shell/Styles/MenuScrollViewerStyle.xaml"
-        //},
+        {
+          (object) typeof (MenuItem),
+          "/XrmTools;component/Shell/Styles/MenuItemStyle.xaml"
+        },
+        {
+          (object) typeof (MenuScrollViewer),
+          "/XrmTools;component/Shell/Styles/MenuScrollViewerStyle.xaml"
+        },
         //{
         //  (object) typeof (MessageContent),
         //  "/XrmTools;component/Shell/Styles/Window/MessageContentStyle.xaml"
@@ -215,10 +215,10 @@ internal static class DefaultStyles
         //  (object) typeof (Section),
         //  "/XrmTools;component/Shell/Styles/MarkdownViewer/SectionStyle.xaml"
         //},
-        //{
-        //  (object) typeof (Separator),
-        //  "/XrmTools;component/Shell/Styles/SeparatorStyle.xaml"
-        //},
+        {
+          (object) typeof (Separator),
+          "/XrmTools;component/Shell/Styles/SeparatorStyle.xaml"
+        },
         //{
         //  (object) typeof (SplitButton),
         //  "/XrmTools;component/Shell/Styles/SplitButtonStyle.xaml"

--- a/src/XrmTools/Shell/Styles/FlyoutSurfaceStyle.xaml
+++ b/src/XrmTools/Shell/Styles/FlyoutSurfaceStyle.xaml
@@ -1,0 +1,70 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:cvrts="clr-namespace:XrmTools.Shell.Converters"
+                    xmlns:imgbg="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <Style TargetType="{x:Type ctrls:FlyoutSurface}">
+        <Setter Property="Control.Background"
+            Value="{DynamicResource {x:Static styles:ShellColors.SurfaceBackgroundFillDefaultBrushKey}}"/>
+        <Setter Property="Control.BorderBrush"
+            Value="{DynamicResource {x:Static styles:ShellColors.SurfaceStrokeFlyoutBrushKey}}"/>
+        <Setter Property="Control.BorderThickness" Value="{x:Static styles:StrokeWidths.Thin}"/>
+        <Setter Property="UIElement.Focusable" Value="False"/>
+        <Setter Property="Control.FontFamily"
+            Value="{Binding ShellFontFamily, Source={x:Static styles:Typography.Instance}}"/>
+        <Setter Property="Control.FontSize"
+            Value="{Binding ShellFontSize, Source={x:Static styles:Typography.Instance}}"/>
+        <Setter Property="imgbg:ImageThemingUtilities.ImageBackgroundColor"
+            Value="{DynamicResource {x:Static styles:ShellColors.SolidBackgroundFillTertiaryColorKey}}"/>
+        <Setter Property="Control.Padding" Value="{x:Static ctrls:FlyoutSurface.ShadowMargin}"/>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ctrls:FlyoutSurface}">
+                    <ctrls:PassThroughBorder>
+                        <Grid Margin="{TemplateBinding Control.Padding}">
+                            <Border x:Name="DropShadowBorder" Background="{TemplateBinding Control.Background}"
+                      BorderBrush="Transparent" BorderThickness="{TemplateBinding Control.BorderThickness}"
+                      CornerRadius="{x:Static styles:CornerRadii.XL}"/>
+                            <Border x:Name="ContentBorder" Background="{TemplateBinding Control.Background}"
+                      BorderBrush="{TemplateBinding Control.BorderBrush}"
+                      BorderThickness="{TemplateBinding Control.BorderThickness}"
+                      CornerRadius="{x:Static styles:CornerRadii.L}"
+                      MinHeight="{TemplateBinding FrameworkElement.MinHeight}"
+                      MinWidth="{TemplateBinding FrameworkElement.MinWidth}">
+                                <ContentPresenter Content="{TemplateBinding ContentControl.Content}">
+                                    <UIElement.Clip>
+                                        <MultiBinding Converter="{x:Static cvrts:Converters.ClipConverter}">
+                                            <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}"/>
+                                            <Binding Path="ActualHeight" RelativeSource="{RelativeSource Self}"/>
+                                            <Binding Path="CornerRadius" ElementName="ContentBorder"/>
+                                        </MultiBinding>
+                                    </UIElement.Clip>
+                                </ContentPresenter>
+                            </Border>
+                        </Grid>
+                    </ctrls:PassThroughBorder>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Value="True" Binding="{Binding GradientsAllowed, Source={x:Static styles:VisualOptions.Instance}}">
+                            <Setter TargetName="DropShadowBorder" Property="UIElement.Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect BlurRadius="{x:Static ctrls:FlyoutSurface.ShadowSize}"
+                                    Color="{DynamicResource {x:Static styles:ShellColors.ShadowFlyoutColorKey}}" Direction="270"
+                                    ShadowDepth="4"
+                                    Opacity="{Binding Color, RelativeSource={RelativeSource Self}, Converter={x:Static cvrts:Converters.ColorOpacityConverter}}"/>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="UIElement.IsVisible" Value="False">
+                <Setter Property="Control.Background" Value="Transparent"/>
+                <Setter Property="Control.BorderBrush" Value="Transparent"/>
+                <Setter Property="imgbg:ImageThemingUtilities.ImageBackgroundColor" Value="Transparent"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/MenuItemStyle.xaml
+++ b/src/XrmTools/Shell/Styles/MenuItemStyle.xaml
@@ -1,0 +1,54 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="SubmenuTemplate.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+    <Style TargetType="{x:Type ctrls:MenuItem}">
+        <Setter Property="Control.Background"
+            Value="{DynamicResource {x:Static styles:ShellColors.ControlFillTransparentBrushKey}}"/>
+        <Setter Property="Control.BorderBrush"
+            Value="{DynamicResource {x:Static styles:ShellColors.ControlStrokeTransparentBrushKey}}"/>
+        <Setter Property="Control.BorderThickness" Value="{x:Static styles:StrokeWidths.Thin}"/>
+        <Setter Property="FrameworkElement.FocusVisualStyle" Value="{x:Static styles:ShellStyles.FocusVisual}"/>
+        <Setter Property="Control.Foreground"
+            Value="{DynamicResource {x:Static styles:ShellColors.TextFillPrimaryBrushKey}}"/>
+        <Setter Property="FrameworkElement.MaxWidth" Value="{x:Static ctrls:FlyoutSurface.ControlMaxWidth}"/>
+        <Setter Property="FrameworkElement.MinHeight" Value="{x:Static styles:Sizes.ControlMinHeight}"/>
+        <Setter Property="FrameworkElement.MinWidth" Value="{x:Static styles:Sizes.ControlMinWidth}"/>
+        <Setter Property="Control.Padding" Value="{x:Static styles:Spacings.HorizontalXXS}"/>
+        <Style.Triggers>
+            <Trigger Property="UIElement.IsEnabled" Value="False">
+                <Setter Property="Control.Foreground"
+                Value="{DynamicResource {x:Static styles:ShellColors.TextFillDisabledBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="UIElement.IsMouseOver" Value="True">
+                <Setter Property="Control.Background"
+                Value="{DynamicResource {x:Static styles:ShellColors.SubtleFillSecondaryBrushKey}}"/>
+                <Setter Property="Control.BorderBrush"
+                Value="{DynamicResource {x:Static styles:ShellColors.ControlStrokeSecondaryBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="MenuItem.IsHighlighted" Value="True">
+                <Setter Property="Control.Background"
+                Value="{DynamicResource {x:Static styles:ShellColors.SubtleFillSecondaryBrushKey}}"/>
+                <Setter Property="Control.BorderBrush"
+                Value="{DynamicResource {x:Static styles:ShellColors.ControlStrokeSecondaryBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="MenuItem.IsPressed" Value="True">
+                <Setter Property="Control.Background"
+                Value="{DynamicResource {x:Static styles:ShellColors.SubtleFillTertiaryBrushKey}}"/>
+                <Setter Property="Control.BorderBrush"
+                Value="{DynamicResource {x:Static styles:ShellColors.SubtleFillTertiaryBrushKey}}"/>
+                <Setter Property="Control.Foreground"
+                Value="{DynamicResource {x:Static styles:ShellColors.TextFillSecondaryBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="MenuItem.Role" Value="SubmenuHeader">
+                <Setter Property="Control.Template" Value="{StaticResource SubmenuTemplate}"/>
+            </Trigger>
+            <Trigger Property="MenuItem.Role" Value="SubmenuItem">
+                <Setter Property="Control.Template" Value="{StaticResource SubmenuTemplate}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/MenuScrollViewerStyle.xaml
+++ b/src/XrmTools/Shell/Styles/MenuScrollViewerStyle.xaml
@@ -1,0 +1,90 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <MenuScrollingVisibilityConverter x:Key="MenuScrollingVisibilityConverter"/>
+    <Style x:Key="RepeatButtonStyle" TargetType="{x:Type RepeatButton}">
+        <Setter Property="Control.Background"
+            Value="{DynamicResource {x:Static styles:ShellColors.ControlFillTransparentBrushKey}}"/>
+        <Setter Property="Control.BorderBrush"
+            Value="{DynamicResource {x:Static styles:ShellColors.ControlStrokeTransparentBrushKey}}"/>
+        <Setter Property="ButtonBase.ClickMode" Value="Hover"/>
+        <Setter Property="UIElement.Focusable" Value="False"/>
+        <Setter Property="Control.Foreground"
+            Value="{DynamicResource {x:Static styles:ShellColors.TextFillPrimaryBrushKey}}"/>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <Border Background="{TemplateBinding Control.Background}"
+                  BorderBrush="{TemplateBinding Control.BorderBrush}">
+                        <Path Data="{TemplateBinding ContentControl.Content}" Fill="{TemplateBinding Control.Foreground}"
+                  Height="{x:Static styles:Sizes.IconS}" HorizontalAlignment="Center" VerticalAlignment="Center"
+                  Width="{x:Static styles:Sizes.IconS}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="UIElement.IsMouseOver" Value="True">
+                <Setter Property="Control.Background"
+                Value="{DynamicResource {x:Static styles:ShellColors.SubtleFillSecondaryBrushKey}}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type ctrls:MenuScrollViewer}">
+        <Setter Property="UIElement.Focusable" Value="False"/>
+        <Setter Property="FrameworkElement.FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden"/>
+        <Setter Property="UIElement.SnapsToDevicePixels" Value="True"/>
+        <Setter Property="FrameworkElement.UseLayoutRounding" Value="True"/>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ctrls:MenuScrollViewer}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+						<!--AutomationProperties.Name="{x:Static styles:Resources.ScrollUp}"-->
+                        <RepeatButton Grid.Row="0" AutomationProperties.Name="Scroll Up"
+                          Command="{x:Static ScrollBar.LineUpCommand}"
+                          Content="{x:Static styles:Geometries.ScrollBarUpArrow}" Style="{StaticResource RepeatButtonStyle}"
+                          CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}">
+                            <UIElement.Visibility>
+                                <MultiBinding Converter="{StaticResource MenuScrollingVisibilityConverter}" ConverterParameter="0"
+                              FallbackValue="Visibility.Collapsed">
+                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                </MultiBinding>
+                            </UIElement.Visibility>
+                        </RepeatButton>
+                        <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" Grid.Row="1"
+                                    CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" CanHorizontallyScroll="False"
+                                    CanVerticallyScroll="False" Content="{TemplateBinding ContentControl.Content}"
+                                    ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
+                                    Margin="{TemplateBinding Control.Padding}"/>
+                        <RepeatButton Grid.Row="2" AutomationProperties.Name="Scroll Down"
+                          Command="{x:Static ScrollBar.LineDownCommand}"
+                          Content="{x:Static styles:Geometries.ScrollBarDownArrow}"
+                          Style="{StaticResource RepeatButtonStyle}"
+                          CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}">
+                            <UIElement.Visibility>
+                                <MultiBinding Converter="{StaticResource MenuScrollingVisibilityConverter}" ConverterParameter="100"
+                              FallbackValue="Visibility.Collapsed">
+                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                </MultiBinding>
+                            </UIElement.Visibility>
+                        </RepeatButton>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/Popup.xaml
+++ b/src/XrmTools/Shell/Styles/Popup.xaml
@@ -1,0 +1,22 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <Style TargetType="{x:Type ctrls:Popup}">
+        <Setter Property="Popup.AllowsTransparency" Value="True"/>
+        <Setter Property="ctrls:Popup.FocusOnOpen" Value="True"/>
+        <Setter Property="FrameworkElement.FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Popup.HorizontalOffset" Value="{x:Static ctrls:FlyoutSurface.HorizontalOffsetInvert}"/>
+        <Setter Property="UIElement.SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="FrameworkElement.UseLayoutRounding" Value="True"/>
+        <Style.Triggers>
+            <Trigger Property="Popup.Placement" Value="Mouse">
+                <Setter Property="Popup.VerticalOffset" Value="{x:Static ctrls:FlyoutSurface.VerticalOffsetInvert}"/>
+            </Trigger>
+            <Trigger Property="Popup.Placement" Value="MousePoint">
+                <Setter Property="Popup.VerticalOffset" Value="{x:Static ctrls:FlyoutSurface.VerticalOffsetInvert}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/SeparatorStyle.xaml
+++ b/src/XrmTools/Shell/Styles/SeparatorStyle.xaml
@@ -1,0 +1,23 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <Style TargetType="{x:Type ctrls:Separator}">
+        <Setter Property="Control.Background"
+            Value="{DynamicResource {x:Static styles:ShellColors.DividerStrokeDefaultBrushKey}}"/>
+        <Setter Property="UIElement.Focusable" Value="False"/>
+        <Setter Property="UIElement.IsHitTestVisible" Value="False"/>
+        <Setter Property="FrameworkElement.Margin" Value="{x:Static styles:Spacings.XXS}"/>
+        <Setter Property="FrameworkElement.MinHeight" Value="{x:Static ctrls:Separator.StrokeWidth}"/>
+        <Setter Property="FrameworkElement.MinWidth" Value="{x:Static ctrls:Separator.StrokeWidth}"/>
+        <Setter Property="UIElement.SnapsToDevicePixels" Value="True"/>
+        <Setter Property="FrameworkElement.UseLayoutRounding" Value="True"/>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ctrls:Separator}">
+                    <Border Background="{TemplateBinding Control.Background}"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/SubmenuTemplate.xaml
+++ b/src/XrmTools/Shell/Styles/SubmenuTemplate.xaml
@@ -1,0 +1,82 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ctrls="clr-namespace:XrmTools.Shell.Controls"
+                    xmlns:styles="clr-namespace:XrmTools.Shell.Styles">
+    <Path x:Key="CheckedGlyph" x:Shared="false" Data="{x:Static styles:Geometries.CheckBoxCheckmark}"
+        Height="{x:Static styles:Sizes.IconS}" HorizontalAlignment="Center" VerticalAlignment="Center"
+        Width="{x:Static styles:Sizes.IconS}"
+        Fill="{Binding (TextElement.Foreground), RelativeSource={RelativeSource Self}}"/>
+    <Path x:Key="SelectedGlyph" x:Shared="false" Data="{x:Static styles:Geometries.DotSmall}"
+        Height="{x:Static styles:Sizes.IconS}" HorizontalAlignment="Center" VerticalAlignment="Center"
+        Width="{x:Static styles:Sizes.IconS}"
+        Fill="{Binding (TextElement.Foreground), RelativeSource={RelativeSource Self}}"/>
+    <ControlTemplate x:Key="SubmenuTemplate" TargetType="{x:Type ctrls:MenuItem}">
+        <Border x:Name="ControlBorder" Background="{TemplateBinding Control.Background}"
+            BorderBrush="{TemplateBinding Control.BorderBrush}"
+            BorderThickness="{TemplateBinding Control.BorderThickness}"
+            CornerRadius="{x:Static styles:CornerRadii.M}" Padding="{TemplateBinding Control.Padding}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="{x:Static styles:Sizes.ControlMinWidth}" SharedSizeGroup="MenuItemIconColumnGroup"
+                            Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="{x:Static ctrls:MenuItem.HeaderGestureSpaceGridLength}"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter Grid.Column="0" ContentSource="Icon" HorizontalAlignment="Center" VerticalAlignment="Center"
+                          Width="{x:Static styles:Sizes.IconS}"
+                          Height="{Binding ActualWidth, RelativeSource={RelativeSource Self}}"/>
+                <ContentPresenter Grid.Column="1" ContentSource="Header" Margin="{x:Static styles:Spacings.HorizontalXXS}"
+                          MinHeight="{x:Static styles:Sizes.ContentMinHeight}" RecognizesAccessKey="True"
+                          SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}" VerticalAlignment="Center"/>
+                <TextBlock x:Name="ShortcutText" Grid.Column="3"
+                   Foreground="{DynamicResource {x:Static styles:ShellColors.TextFillSecondaryBrushKey}}"
+                   HorizontalAlignment="Right" Margin="{x:Static styles:Spacings.HorizontalXXS}"
+                   MinHeight="{x:Static styles:Sizes.ContentMinHeight}"
+                   Text="{TemplateBinding MenuItem.InputGestureText}" VerticalAlignment="Center"/>
+                <Path x:Name="Arrow" Grid.Column="3" Data="{x:Static styles:Geometries.ChevronRightSmall}"
+              Fill="{TemplateBinding TextElement.Foreground}" Height="{x:Static styles:Sizes.IconS}"
+              HorizontalAlignment="Center" Margin="{x:Static styles:Spacings.HorizontalXXS}"
+              VerticalAlignment="Center" Width="{x:Static styles:Sizes.IconS}"/>
+                <ctrls:Popup x:Name="PART_Popup" FocusOnOpen="False"
+                     VerticalOffset="{x:Static ctrls:FlyoutSurface.VerticalOffsetInvert}"
+                     IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                     PlacementTarget="{Binding ElementName=ControlBorder}"
+                     Visibility="{Binding Visibility, ElementName=Arrow}">
+                    <ctrls:MenuScrollViewer>
+                        <ItemsPresenter Grid.Column="1" Grid.IsSharedSizeScope="True" KeyboardNavigation.DirectionalNavigation="Cycle"
+                            KeyboardNavigation.TabNavigation="Cycle" Margin="{x:Static styles:Spacings.XSNudge}"
+                            SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}"/>
+                    </ctrls:MenuScrollViewer>
+                </ctrls:Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="MenuItem.Role" Value="SubmenuItem">
+                <Setter TargetName="Arrow" Property="UIElement.Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="MenuItem.Role" Value="SubmenuHeader">
+                <Setter TargetName="ShortcutText" Property="UIElement.Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="UIElement.IsEnabled" Value="False">
+                <Setter TargetName="ShortcutText"
+                Value="{DynamicResource {x:Static styles:ShellColors.TextFillDisabledBrushKey}}"
+                Property="TextBlock.Foreground"/>
+            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="MenuItem.IsCheckable" Value="True"/>
+                    <Condition Property="MenuItem.IsChecked" Value="True"/>
+                </MultiTrigger.Conditions>
+                <Setter Value="{StaticResource CheckedGlyph}" Property="MenuItem.Icon"/>
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="ctrls:MenuItem.IsSelectable" Value="True"/>
+                    <Condition Property="ctrls:MenuItem.IsSelected" Value="True"/>
+                </MultiTrigger.Conditions>
+                <Setter Value="{StaticResource SelectedGlyph}" Property="MenuItem.Icon"/>
+            </MultiTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+</ResourceDictionary>

--- a/src/XrmTools/Shell/Styles/Typography.cs
+++ b/src/XrmTools/Shell/Styles/Typography.cs
@@ -1,0 +1,172 @@
+﻿namespace XrmTools.Shell.Styles;
+
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Utilities;
+using System;
+using System.Text;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+public class Typography : Microsoft.VisualStudio.PlatformUI.ObservableObject, IVsBroadcastMessageEvents
+{
+    private const uint WM_SYSCOLORCHANGE = 21;
+    public static readonly double BodyLineHeight = 20.0;
+    public static readonly double BodyLargeLineHeight = 24.0;
+    public static readonly double CaptionLineHeight = 16.0;
+    public static readonly double CodeLineHeight = 20.0;
+    public static readonly double DisplayLineHeight = 92.0;
+    public static readonly double SubtitleLineHeight = 28.0;
+    public static readonly double TitleLineHeight = 36.0;
+    public static readonly double TitleLargeLineHeight = 52.0;
+    private static Typography? instance;
+    private double bodyFontSize = 14.0;
+    private double bodyLargeFontSize = 18.0;
+    private double captionFontSize = 12.0;
+    private FontFamily codeFontFamily = new FontFamily("Cascadia Mono");
+    private double codeFontSize = 14.0;
+    private double displayFontSize = 68.0;
+    private FontFamily shellFontFamily = new FontFamily("Segoe UI");
+    private double shellFontSize = 12.0;
+    private double subtitleFontSize = 20.0;
+    private double titleFontSize = 28.0;
+    private double titleLargeFontSize = 40.0;
+
+    //TODO: in Microsoft.VisualStudio.PlatformUI v18 chain to `base(false)`
+    private Typography()
+      : base() //false)
+    {
+        Dispatcher.CurrentDispatcher.VerifyAccess();
+        if (!(ServiceProvider.GlobalProvider.GetService(typeof(SVsShell)) is IVsShell service))
+            return;
+        this.UpdateFontValues();
+        service.AdviseBroadcastMessages((IVsBroadcastMessageEvents)this, out uint _);
+    }
+
+    public static Typography Instance
+    {
+        get => Typography.instance ?? (Typography.instance = new Typography());
+    }
+
+    public double BodyFontSize
+    {
+        get => this.bodyFontSize;
+        private set => this.SetProperty<double>(ref this.bodyFontSize, value, nameof(BodyFontSize));
+    }
+
+    public double BodyLargeFontSize
+    {
+        get => this.bodyLargeFontSize;
+        private set
+        {
+            this.SetProperty<double>(ref this.bodyLargeFontSize, value, nameof(BodyLargeFontSize));
+        }
+    }
+
+    public double CaptionFontSize
+    {
+        get => this.captionFontSize;
+        private set
+        {
+            this.SetProperty<double>(ref this.captionFontSize, value, nameof(CaptionFontSize));
+        }
+    }
+
+    public FontFamily CodeFontFamily
+    {
+        get => this.codeFontFamily;
+        private set
+        {
+            this.SetProperty<FontFamily>(ref this.codeFontFamily, value, nameof(CodeFontFamily));
+        }
+    }
+
+    public double CodeFontSize
+    {
+        get => this.codeFontSize;
+        private set => this.SetProperty<double>(ref this.codeFontSize, value, nameof(CodeFontSize));
+    }
+
+    public double DisplayFontSize
+    {
+        get => this.displayFontSize;
+        private set
+        {
+            this.SetProperty<double>(ref this.displayFontSize, value, nameof(DisplayFontSize));
+        }
+    }
+
+    public FontFamily ShellFontFamily
+    {
+        get => this.shellFontFamily;
+        private set
+        {
+            this.SetProperty<FontFamily>(ref this.shellFontFamily, value, nameof(ShellFontFamily));
+        }
+    }
+
+    public double ShellFontSize
+    {
+        get => this.shellFontSize;
+        private set => this.SetProperty<double>(ref this.shellFontSize, value, nameof(ShellFontSize));
+    }
+
+    public double SubtitleFontSize
+    {
+        get => this.subtitleFontSize;
+        private set
+        {
+            this.SetProperty<double>(ref this.subtitleFontSize, value, nameof(SubtitleFontSize));
+        }
+    }
+
+    public double TitleFontSize
+    {
+        get => this.titleFontSize;
+        private set => this.SetProperty<double>(ref this.titleFontSize, value, nameof(TitleFontSize));
+    }
+
+    public double TitleLargeFontSize
+    {
+        get => this.titleLargeFontSize;
+        private set
+        {
+            this.SetProperty<double>(ref this.titleLargeFontSize, value, nameof(TitleLargeFontSize));
+        }
+    }
+
+    int IVsBroadcastMessageEvents.OnBroadcastMessage(uint msg, IntPtr wParam, IntPtr lParam)
+    {
+        if (msg == 21U)
+            this.UpdateFontValues();
+        return 0;
+    }
+
+    private string GetFontFamilyName(UIDLGLOGFONT logFont)
+    {
+        StringBuilder stringBuilder = new StringBuilder(32 /*0x20*/);
+        for (int index = 0; index < logFont.lfFaceName.Length && logFont.lfFaceName[index] != (ushort)0; ++index)
+            stringBuilder.Append((char)logFont.lfFaceName[index]);
+        return stringBuilder.ToString();
+    }
+
+    private void UpdateFontValues()
+    {
+        if (!(ServiceProvider.GlobalProvider.GetService(typeof(SUIHostLocale)) is IUIHostLocale service))
+            return;
+        UIDLGLOGFONT[] pLOGFONT = new UIDLGLOGFONT[1];
+        if (Microsoft.VisualStudio.ErrorHandler.Failed(service.GetDialogFont(pLOGFONT)))
+            return;
+        this.ShellFontFamily = new FontFamily(this.GetFontFamilyName(pLOGFONT[0]));
+        this.ShellFontSize = (double)Math.Abs(pLOGFONT[0].lfHeight) * 96.0 / DpiAwareness.SystemDpiY;
+        this.BodyFontSize = Math.Round(this.ShellFontSize * 1.1667);
+        this.BodyLargeFontSize = Math.Round(this.ShellFontSize * 1.5);
+        this.CaptionFontSize = this.ShellFontSize;
+        this.CodeFontSize = Math.Round(this.ShellFontSize * 1.1667);
+        this.DisplayFontSize = Math.Round(this.ShellFontSize * 5.6667);
+        this.SubtitleFontSize = Math.Round(this.ShellFontSize * 1.6667);
+        this.TitleFontSize = Math.Round(this.ShellFontSize * 2.3333);
+        this.TitleLargeFontSize = Math.Round(this.ShellFontSize * 3.3333);
+    }
+}

--- a/src/XrmTools/Shell/Styles/VisualOptions.cs
+++ b/src/XrmTools/Shell/Styles/VisualOptions.cs
@@ -1,0 +1,151 @@
+﻿#nullable enable
+namespace XrmTools.Shell.Styles;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.Win32;
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+public class VisualOptions : ObservableObject, IVsShellPropertyEvents
+{
+    private const string AccessibilityRoot = "Control Panel\\Accessibility";
+    private const string DynamicScrollBarsName = "DynamicScrollbars";
+    private static readonly UIContext FeedbackEnabledContext = UIContext.FromUIContextGuid(new Guid("FC108F5B-6AB6-422E-BA84-2A33EFA464F3"));
+    private static VisualOptions? instance;
+    private Lazy<bool> areDynamicScrollBarsEnabled = new Lazy<bool>(GetDynamicScrollBars); private bool gradientsAllowed;
+    private bool isFeedbackDisabledByPolicy;
+    private double systemHorizontalScrollBarHeight;
+    private double systemVerticalScrollBarWidth;
+
+    //TODO: in Microsoft.VisualStudio.PlatformUI v18 chain to `base(false)`
+    private VisualOptions()
+      : base() //false)
+    {
+        Dispatcher.CurrentDispatcher.VerifyAccess();
+        this.AdviseShellEvents();
+        this.HookFeedbackUIContext();
+        this.InitializeScrollBarValues();
+    }
+
+    public static VisualOptions Instance
+    {
+        get => VisualOptions.instance ?? (VisualOptions.instance = new VisualOptions());
+    }
+
+    public bool AreDynamicScrollBarsEnabled => this.areDynamicScrollBarsEnabled.Value;
+
+    public bool GradientsAllowed
+    {
+        get => this.gradientsAllowed;
+        private set
+        {
+            this.SetProperty<bool>(ref this.gradientsAllowed, value, nameof(GradientsAllowed));
+        }
+    }
+
+    public bool IsFeedbackDisabledByPolicy
+    {
+        get => this.isFeedbackDisabledByPolicy;
+        private set
+        {
+            this.SetProperty<bool>(ref this.isFeedbackDisabledByPolicy, value, nameof(IsFeedbackDisabledByPolicy));
+        }
+    }
+
+    public double SystemHorizontalScrollBarHeight
+    {
+        get => this.systemHorizontalScrollBarHeight;
+        private set
+        {
+            this.SetProperty<double>(ref this.systemHorizontalScrollBarHeight, value, nameof(SystemHorizontalScrollBarHeight));
+        }
+    }
+
+    public double SystemVerticalScrollBarWidth
+    {
+        get => this.systemVerticalScrollBarWidth;
+        private set
+        {
+            this.SetProperty<double>(ref this.systemVerticalScrollBarWidth, value, nameof(SystemVerticalScrollBarWidth));
+        }
+    }
+
+    public BitmapScalingMode GetBitmapScalingMode(Visual visual)
+    {
+        if (visual == null)
+            return BitmapScalingMode.Unspecified;
+        double dpiX = visual.GetDpiX();
+        return dpiX < 96.0 ? BitmapScalingMode.LowQuality : (dpiX % 96.0 != 0.0 ? BitmapScalingMode.HighQuality : BitmapScalingMode.NearestNeighbor);
+    }
+
+    private void AdviseShellEvents()
+    {
+        Dispatcher.CurrentDispatcher.VerifyAccess();
+        if (!(ServiceProvider.GlobalProvider.GetService(typeof(SVsShell)) is IVsShell service))
+            return;
+        object pvar;
+        if (ErrorHandler.Succeeded(service.GetProperty(-9061, out pvar)))
+            this.UpdateGradientsAllowed((__VISUALEFFECTS)pvar);
+        service.AdviseShellPropertyChanges((IVsShellPropertyEvents)this, out uint _);
+    }
+
+    int IVsShellPropertyEvents.OnShellPropertyChange(int propertyId, object value)
+    {
+        if (propertyId != -9061)
+            return 0;
+        this.UpdateGradientsAllowed((__VISUALEFFECTS)value);
+        return 0;
+    }
+
+    private void UpdateGradientsAllowed(__VISUALEFFECTS value)
+    {
+        this.GradientsAllowed = (value & __VISUALEFFECTS.VISUALEFFECTS_Gradients) != 0;
+    }
+
+    private static bool GetDynamicScrollBars()
+    {
+        return VisualOptions.GetRegistryValueBool("Control Panel\\Accessibility", "DynamicScrollbars", true);
+    }
+
+    private static bool GetRegistryValueBool(string key, string name, bool fallbackValue)
+    {
+        using (RegistryKey registryKey = Registry.CurrentUser.OpenSubKey(key, false))
+            return registryKey?.GetValue(name) is int num ? num != 0 : fallbackValue;
+    }
+
+    private void InitializeScrollBarValues()
+    {
+        this.SystemHorizontalScrollBarHeight = this.ForceEvenNumber(SystemParameters.HorizontalScrollBarHeight);
+        this.SystemVerticalScrollBarWidth = this.ForceEvenNumber(SystemParameters.VerticalScrollBarWidth);
+        SystemParameters.StaticPropertyChanged += new PropertyChangedEventHandler(this.OnSystemParametersChanged);
+    }
+
+    private double ForceEvenNumber(double value) => value - Math.Floor(value) % 2.0;
+
+    private void OnSystemParametersChanged(object sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case "HorizontalScrollBarHeight":
+                this.SystemHorizontalScrollBarHeight = this.ForceEvenNumber(SystemParameters.HorizontalScrollBarHeight);
+                break;
+            case "VerticalScrollBarWidth":
+                this.SystemVerticalScrollBarWidth = this.ForceEvenNumber(SystemParameters.VerticalScrollBarWidth);
+                break;
+        }
+    }
+
+    private void HookFeedbackUIContext()
+    {
+        Dispatcher.CurrentDispatcher.VerifyAccess();
+        this.IsFeedbackDisabledByPolicy = !VisualOptions.FeedbackEnabledContext.IsActive;
+        VisualOptions.FeedbackEnabledContext.UIContextChanged += (EventHandler<UIContextChangedEventArgs>)((s, e) => this.IsFeedbackDisabledByPolicy = !e.Activated);
+    }
+}

--- a/src/XrmTools/XrmTools.csproj
+++ b/src/XrmTools/XrmTools.csproj
@@ -99,17 +99,29 @@
     <Compile Include="DataverseExplorer\Views\TreeViewScrollBehavior.cs" />
     <Compile Include="Helpers\SolutionNavigator.cs" />
     <Compile Include="Shell\Controls\Expander.cs" />
+    <Compile Include="Shell\Controls\FlyoutSurface.cs" />
     <Compile Include="Shell\Controls\Indicator.cs" />
     <Compile Include="Shell\Controls\ListBoxItem.cs" />
+    <Compile Include="Shell\Controls\MenuItem.cs" />
+    <Compile Include="Shell\Controls\MenuScrollViewer.cs" />
+    <Compile Include="Shell\Controls\PassThroughBorder.cs" />
+    <Compile Include="Shell\Controls\Popup.cs" />
     <Compile Include="Shell\Controls\ScrollBar.cs" />
     <Compile Include="Shell\Controls\ScrollViewer.cs" />
+    <Compile Include="Shell\Controls\ContextMenu.cs" />
+    <Compile Include="Shell\Controls\Separator.cs" />
     <Compile Include="Shell\Controls\ToggleButton.cs" />
     <Compile Include="Shell\Controls\TreeView.cs" />
     <Compile Include="Shell\Controls\TreeViewItem.cs" />
+    <Compile Include="Shell\Conveters\BitmapScalingModeConverter.cs" />
+    <Compile Include="Shell\Conveters\ClipConverter.cs" />
+    <Compile Include="Shell\Conveters\ColorOpacityConverter.cs" />
     <Compile Include="Shell\Conveters\Converters.cs" />
     <Compile Include="Shell\Helpers\Boxes.cs" />
     <Compile Include="Shell\Helpers\Property.cs" />
+    <Compile Include="Shell\Helpers\VisualTree.cs" />
     <Compile Include="Shell\Styles\ButtonKind.cs" />
+    <Compile Include="Shell\Styles\ClipConverter.cs" />
     <Compile Include="Shell\Styles\CornerRadii.cs" />
     <Compile Include="Shell\Styles\DefaultStyles.cs" />
     <Compile Include="Shell\Styles\DeferredStyleDictionary.cs" />
@@ -122,7 +134,14 @@
     <Page Include="Shell\Styles\ButtonBaseStyle.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Shell\Styles\ContextMenuStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Shell\Styles\ExpanderStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Shell\Styles\FlyoutSurfaceStyle.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Shell\Styles\FocusVisualStyle.xaml">
@@ -137,6 +156,16 @@
     <Page Include="Shell\Styles\ListBoxItemBaseStyle.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Shell\Styles\MenuItemStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Shell\Styles\MenuScrollViewerStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Shell\Styles\Popup.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Shell\Styles\ScrollViewerStyle.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -146,6 +175,8 @@
     <Compile Include="Shell\Styles\Sizes.cs" />
     <Compile Include="Shell\Styles\Spacings.cs" />
     <Compile Include="Shell\Styles\StrokeWidths.cs" />
+    <Compile Include="Shell\Styles\Typography.cs" />
+    <Compile Include="Shell\Styles\VisualOptions.cs" />
     <Compile Include="UI\VsPluginRegistrationUI.cs" />
     <Compile Include="Core\Repositories\ICacheConfiguration.cs" />
     <Compile Include="CustomMonikers.cs">
@@ -475,6 +506,9 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
+    <Reference Include="UIAutomationClient" />
+    <Reference Include="UIAutomationProvider" />
+    <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
@@ -549,6 +583,12 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Shell\Styles\ScrollBarStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Shell\Styles\SeparatorStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Shell\Styles\SubmenuTemplate.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Shell\Styles\ToggleButtonStyle.xaml">


### PR DESCRIPTION
Add custom menu controls and styles for WPF shell

Introduced custom WPF controls for menu infrastructure: ContextMenu, MenuItem, MenuScrollViewer, FlyoutSurface, Popup, Separator, and PassThroughBorder, each with specialized logic and dependency properties. Added supporting helpers and converters (VisualTree, BitmapScalingModeConverter, ClipConverter, ColorOpacityConverter) and registered them in Converters.cs. Created new style resource dictionaries for these controls and registered them in DefaultStyles.cs. Added Typography and VisualOptions classes for centralized font and visual system settings. Updated XrmTools.csproj to include all new files and UIAutomation references. Integrated all new controls and styles into the build and resource system.