### PR TITLE
Do not allow async+preoperation or prevalidation combos

### DIFF
--- a/src/Analyzers/XrmTools.Analyzers.Test/XrmToolsAnalyzersUnitTests.cs
+++ b/src/Analyzers/XrmTools.Analyzers.Test/XrmToolsAnalyzersUnitTests.cs
@@ -30,8 +30,28 @@ namespace XrmTools.Meta.Attributes
     [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public sealed class CustomApiAttribute : System.Attribute { }
 
+    public enum Stages
+    {
+        PreValidation = 10,
+        PreOperation = 20,
+        MainOperation = 30,
+        PostOperation = 40,
+    }
+
+    public enum ExecutionMode
+    {
+        Synchronous = 0,
+        Asynchronous = 1,
+    }
+
     [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public sealed class StepAttribute : System.Attribute { }
+    public sealed class StepAttribute : System.Attribute
+    {
+        public StepAttribute(string messageName, Stages stage, ExecutionMode mode) { }
+        public StepAttribute(string messageName, string primaryEntityName, Stages stage, ExecutionMode mode) { }
+        public StepAttribute(string messageName, string primaryEntityName, string filteringAttributes, Stages stage, ExecutionMode mode) { }
+        public ExecutionMode Mode { get; set; }
+    }
 
     [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public sealed class ImageAttribute : System.Attribute { }
@@ -273,7 +293,7 @@ public sealed class MyPlugin : PluginBase
     public async Task Plugin_PluginAttributeMustComeBeforeStep_ReportsXrmTools004()
     {
         var test = Preamble + @"
-[XrmTools.Meta.Attributes.Step]
+[XrmTools.Meta.Attributes.Step(""Create"", XrmTools.Meta.Attributes.Stages.PostOperation, XrmTools.Meta.Attributes.ExecutionMode.Synchronous)]
 [XrmTools.Meta.Attributes.Plugin]
 public sealed class {|#0:MyPlugin|} : PluginBase
 {
@@ -311,7 +331,7 @@ public sealed class {|#0:MyPlugin|} : PluginBase
         var test = Preamble + @"
 [XrmTools.Meta.Attributes.Plugin]
 [XrmTools.Meta.Attributes.Image]
-[XrmTools.Meta.Attributes.Step]
+[XrmTools.Meta.Attributes.Step(""Create"", XrmTools.Meta.Attributes.Stages.PostOperation, XrmTools.Meta.Attributes.ExecutionMode.Synchronous)]
 public sealed class {|#0:MyPlugin|} : PluginBase
 {
 }
@@ -329,7 +349,7 @@ public sealed class {|#0:MyPlugin|} : PluginBase
     {
         var test = Preamble + @"
 [XrmTools.Meta.Attributes.Plugin]
-[XrmTools.Meta.Attributes.Step]
+[XrmTools.Meta.Attributes.Step(""Create"", XrmTools.Meta.Attributes.Stages.PostOperation, XrmTools.Meta.Attributes.ExecutionMode.Synchronous)]
 [XrmTools.Meta.Attributes.Image]
 public sealed class MyPlugin : PluginBase
 {
@@ -344,10 +364,96 @@ public sealed class MyPlugin : PluginBase
     {
         var test = Preamble + @"
 [XrmTools.Meta.Attributes.Plugin]
-[XrmTools.Meta.Attributes.Step]
+[XrmTools.Meta.Attributes.Step(""Create"", XrmTools.Meta.Attributes.Stages.PostOperation, XrmTools.Meta.Attributes.ExecutionMode.Synchronous)]
 [XrmTools.Meta.Attributes.Image]
-[XrmTools.Meta.Attributes.Step]
+[XrmTools.Meta.Attributes.Step(""Update"", ""account"", XrmTools.Meta.Attributes.Stages.PostOperation, XrmTools.Meta.Attributes.ExecutionMode.Synchronous)]
 [XrmTools.Meta.Attributes.Image]
+public sealed class MyPlugin : PluginBase
+{
+}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Plugin_PreValidationAsyncStep_ReportsXrmTools006()
+    {
+        var test = Preamble + @"
+[XrmTools.Meta.Attributes.Plugin]
+[{|#0:XrmTools.Meta.Attributes.Step(""Create"", XrmTools.Meta.Attributes.Stages.PreValidation, XrmTools.Meta.Attributes.ExecutionMode.Asynchronous)|}]
+public sealed class MyPlugin : PluginBase
+{
+}
+";
+
+        var expected = new DiagnosticResult(PluginDependencyAnalyzer.InvalidStepStageModeId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Stages.PreValidation");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Plugin_PreOperationAsyncStep_WithPrimaryEntityConstructor_ReportsXrmTools006()
+    {
+        var test = Preamble + @"
+[XrmTools.Meta.Attributes.Plugin]
+[{|#0:XrmTools.Meta.Attributes.Step(""Update"", ""account"", XrmTools.Meta.Attributes.Stages.PreOperation, XrmTools.Meta.Attributes.ExecutionMode.Asynchronous)|}]
+public sealed class MyPlugin : PluginBase
+{
+}
+";
+
+        var expected = new DiagnosticResult(PluginDependencyAnalyzer.InvalidStepStageModeId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Stages.PreOperation");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Plugin_PreValidationAsyncStep_WithFilteringAttributesConstructor_ReportsXrmTools006()
+    {
+        var test = Preamble + @"
+[XrmTools.Meta.Attributes.Plugin]
+[{|#0:XrmTools.Meta.Attributes.Step(""Update"", ""account"", ""name"", XrmTools.Meta.Attributes.Stages.PreValidation, XrmTools.Meta.Attributes.ExecutionMode.Asynchronous)|}]
+public sealed class MyPlugin : PluginBase
+{
+}
+";
+
+        var expected = new DiagnosticResult(PluginDependencyAnalyzer.InvalidStepStageModeId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Stages.PreValidation");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Plugin_PreOperationAsyncStep_WithNamedModeOverride_ReportsXrmTools006()
+    {
+        var test = Preamble + @"
+[XrmTools.Meta.Attributes.Plugin]
+[{|#0:XrmTools.Meta.Attributes.Step(""Update"", XrmTools.Meta.Attributes.Stages.PreOperation, XrmTools.Meta.Attributes.ExecutionMode.Synchronous, Mode = XrmTools.Meta.Attributes.ExecutionMode.Asynchronous)|}]
+public sealed class MyPlugin : PluginBase
+{
+}
+";
+
+        var expected = new DiagnosticResult(PluginDependencyAnalyzer.InvalidStepStageModeId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Stages.PreOperation");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Plugin_PostOperationAsyncStep_IsAllowed()
+    {
+        var test = Preamble + @"
+[XrmTools.Meta.Attributes.Plugin]
+[XrmTools.Meta.Attributes.Step(""Create"", XrmTools.Meta.Attributes.Stages.PostOperation, XrmTools.Meta.Attributes.ExecutionMode.Asynchronous)]
 public sealed class MyPlugin : PluginBase
 {
 }

--- a/src/Analyzers/XrmTools.Analyzers/PluginDependencyAnalyzer.cs
+++ b/src/Analyzers/XrmTools.Analyzers/PluginDependencyAnalyzer.cs
@@ -16,6 +16,7 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
     public const string HasSetterOrInitId = "XrmTools002";
     public const string PluginAttributeCombinationId = "XrmTools003";
     public const string PluginAttributeOrderId = "XrmTools004";
+    public const string InvalidStepStageModeId = "XrmTools006";
 
     private static readonly DiagnosticDescriptor MissingDependencyAttributeRule =
         new(
@@ -61,8 +62,19 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
             description: "[Plugin] must appear before [Step]/[CustomApi]. For step plugins, [Image] attributes must appear after [Step].",
             helpLinkUri: "https://github.com/rezanid/xrmtools/wiki/Analyzers#xrmtools004---invalid-plugin-attribute-order");
 
+    private static readonly DiagnosticDescriptor InvalidStepStageModeRule =
+        new(
+            InvalidStepStageModeId,
+            "Step attribute has invalid stage and mode combination",
+            "Step attribute cannot use ExecutionMode.Asynchronous with {0}",
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Dataverse plug-in steps registered in PreValidation or PreOperation must run synchronously.",
+            helpLinkUri: "https://github.com/rezanid/xrmtools/wiki/Analyzers#xrmtools006---invalid-step-stage-and-mode");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        [MissingDependencyAttributeRule, HasSetterOrInitRule, PluginAttributeCombinationRule, PluginAttributeOrderRule];
+        [MissingDependencyAttributeRule, HasSetterOrInitRule, PluginAttributeCombinationRule, PluginAttributeOrderRule, InvalidStepStageModeRule];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -87,13 +99,15 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
             var customApiAttrSymbol = compilationStart.Compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.CustomApiAttribute");
             var stepAttrSymbol = compilationStart.Compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.StepAttribute");
             var imageAttrSymbol = compilationStart.Compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.ImageAttribute");
+            var stageEnumSymbol = compilationStart.Compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.Stages");
+            var executionModeEnumSymbol = compilationStart.Compilation.GetTypeByMetadataName("XrmTools.Meta.Attributes.ExecutionMode");
 
             compilationStart.RegisterSyntaxNodeAction(
                 c => AnalyzeProperty(c, pluginSymbol, dependencyAttrSymbol),
                 SyntaxKind.PropertyDeclaration);
 
             compilationStart.RegisterSymbolAction(
-                c => AnalyzePluginTypeAttributes(c, pluginSymbol, pluginAttrSymbol, customApiAttrSymbol, stepAttrSymbol, imageAttrSymbol),
+                c => AnalyzePluginTypeAttributes(c, pluginSymbol, pluginAttrSymbol, customApiAttrSymbol, stepAttrSymbol, imageAttrSymbol, stageEnumSymbol, executionModeEnumSymbol),
                 SymbolKind.NamedType);
         });
     }
@@ -104,7 +118,9 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol? pluginAttrSymbol,
         INamedTypeSymbol? customApiAttrSymbol,
         INamedTypeSymbol? stepAttrSymbol,
-        INamedTypeSymbol? imageAttrSymbol)
+        INamedTypeSymbol? imageAttrSymbol,
+        INamedTypeSymbol? stageEnumSymbol,
+        INamedTypeSymbol? executionModeEnumSymbol)
     {
         if (pluginAttrSymbol is null || customApiAttrSymbol is null || stepAttrSymbol is null)
             return;
@@ -141,6 +157,8 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
 
             // Keep going; XOR rule may also be violated and should be reported too.
         }
+
+        ReportInvalidStepStageMode(context, typeSymbol, attrs, stepAttrSymbol, stageEnumSymbol, executionModeEnumSymbol);
 
         if (hasCustomApi == hasStep)
         {
@@ -207,6 +225,124 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static void ReportInvalidStepStageMode(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol typeSymbol,
+        ImmutableArray<AttributeData> attributes,
+        INamedTypeSymbol? stepAttrSymbol,
+        INamedTypeSymbol? stageEnumSymbol,
+        INamedTypeSymbol? executionModeEnumSymbol)
+    {
+        if (stepAttrSymbol is null || stageEnumSymbol is null || executionModeEnumSymbol is null)
+            return;
+
+        for (int i = 0; i < attributes.Length; i++)
+        {
+            var attribute = attributes[i];
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, stepAttrSymbol))
+                continue;
+
+            if (!TryGetStepStageAndMode(attribute, stageEnumSymbol, executionModeEnumSymbol, out var stage, out var mode))
+                continue;
+
+            if (mode != 1 || (stage != 10 && stage != 20))
+                continue;
+
+            var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation()
+                ?? typeSymbol.Locations.FirstOrDefault();
+            if (location is null)
+                continue;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                InvalidStepStageModeRule,
+                location,
+                GetStageDisplayName(stage)));
+        }
+    }
+
+    private static bool TryGetStepStageAndMode(
+        AttributeData attribute,
+        INamedTypeSymbol stageEnumSymbol,
+        INamedTypeSymbol executionModeEnumSymbol,
+        out int stage,
+        out int mode)
+    {
+        stage = default;
+        mode = default;
+
+        var hasStage = false;
+        var hasMode = false;
+        var constructor = attribute.AttributeConstructor;
+
+        if (constructor is not null)
+        {
+            var parameterCount = constructor.Parameters.Length;
+            var argumentCount = attribute.ConstructorArguments.Length;
+            var count = parameterCount < argumentCount ? parameterCount : argumentCount;
+
+            for (int i = 0; i < count; i++)
+            {
+                var parameter = constructor.Parameters[i];
+                var argument = attribute.ConstructorArguments[i];
+
+                if (!TryGetEnumValue(argument, out var value))
+                    continue;
+
+                if (!hasStage && SymbolEqualityComparer.Default.Equals(parameter.Type, stageEnumSymbol))
+                {
+                    stage = value;
+                    hasStage = true;
+                    continue;
+                }
+
+                if (!hasMode && SymbolEqualityComparer.Default.Equals(parameter.Type, executionModeEnumSymbol))
+                {
+                    mode = value;
+                    hasMode = true;
+                }
+            }
+        }
+
+        for (int i = 0; i < attribute.NamedArguments.Length; i++)
+        {
+            var namedArgument = attribute.NamedArguments[i];
+            if (namedArgument.Key != "Mode")
+                continue;
+
+            if (!SymbolEqualityComparer.Default.Equals(namedArgument.Value.Type, executionModeEnumSymbol))
+                continue;
+
+            if (!TryGetEnumValue(namedArgument.Value, out mode))
+                continue;
+
+            hasMode = true;
+        }
+
+        return hasStage && hasMode;
+    }
+
+    private static bool TryGetEnumValue(TypedConstant value, out int intValue)
+    {
+        if (value.Value is int typedValue)
+        {
+            intValue = typedValue;
+            return true;
+        }
+
+        intValue = default;
+        return false;
+    }
+
+    private static string GetStageDisplayName(int stage)
+    {
+        return stage switch
+        {
+            10 => "Stages.PreValidation",
+            20 => "Stages.PreOperation",
+            _ => $"stage value {stage}",
+        };
     }
 
     private static void AnalyzeProperty(
@@ -314,7 +450,7 @@ public sealed class PluginDependencyAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool HasSetterOrInit(PropertyDeclarationSyntax propDecl, out Location location)
+    private static bool HasSetterOrInit(PropertyDeclarationSyntax propDecl, out Location? location)
     {
         location = null;
 

--- a/src/Tests/XrmTools.Tests/Logging/OutputLoggerTests.cs
+++ b/src/Tests/XrmTools.Tests/Logging/OutputLoggerTests.cs
@@ -1,0 +1,20 @@
+namespace XrmTools.Tests.Logging;
+using System;
+using FluentAssertions;
+using Xunit;
+using XrmTools.Logging.Compatibility;
+
+public class OutputLoggerTests
+{
+    [Fact]
+    public void AppendException_Should_Include_Exception_Details()
+    {
+        var logRecord = "[Error] TestCategory: Failed to register plugin assembly.";
+        var exception = new InvalidOperationException("Boom");
+
+        var result = OutputLogger.AppendException(logRecord, exception);
+
+        result.Should().StartWith(logRecord + Environment.NewLine);
+        result.Should().Contain(exception.ToString());
+    }
+}

--- a/src/XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj
+++ b/src/XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj
@@ -8,7 +8,7 @@
 	<Title>XrmTools.Meta.Attributes</Title>
 	<Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
 	<PackageId>XrmTools.Meta.Attributes</PackageId>
-	<VersionPrefix>1.1.4</VersionPrefix>
+	<VersionPrefix>1.1.5</VersionPrefix>
 	<Authors>Reza Niroomand</Authors>
 	<PackageIcon>XrmTools_256.png</PackageIcon>
 	<PackageTags>Power Platform Apps XRM Tools</PackageTags>

--- a/src/XrmTools.Meta.Attributes.SourceGenerator/XrmTools.Meta.Attributes.SourceGenerator.csproj
+++ b/src/XrmTools.Meta.Attributes.SourceGenerator/XrmTools.Meta.Attributes.SourceGenerator.csproj
@@ -6,6 +6,7 @@
 	<IsPackable>false</IsPackable>
 	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	<RootNamespace>XrmTools.Meta.Attributes.SourceGenerator</RootNamespace>
+	<VersionPrefix>1.1.5</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
+++ b/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
     <Authors>Reza Niroomand</Authors>
     <PackageIcon>XrmTools_256.png</PackageIcon>

--- a/src/XrmTools/Logging/OutputLogger.cs
+++ b/src/XrmTools/Logging/OutputLogger.cs
@@ -46,12 +46,19 @@ internal class OutputLogger(string name, IOutputLoggerService outputLoggerServic
             logRecord = $"{string.Join(" => ", scopeInfo)}: {logRecord}";
         }
 
-        if (exception != null && logLevel <= LogLevel.Debug)
-        {
-            logRecord += Environment.NewLine + exception.ToString();
-        }
+        logRecord = AppendException(logRecord, exception);
 
         outputLoggerService.OutputString(logRecord + Environment.NewLine);
+    }
+
+    internal static string AppendException(string logRecord, Exception? exception)
+    {
+        if (exception is null)
+        {
+            return logRecord;
+        }
+
+        return logRecord + Environment.NewLine + exception;
     }
 
     private class Scope(object state) : IDisposable

--- a/src/XrmTools/Services/PluginRegistrationService.cs
+++ b/src/XrmTools/Services/PluginRegistrationService.cs
@@ -395,7 +395,7 @@ internal sealed class PluginRegistrationService(
             catch (Exception ex)    
             {
                 _log.LogError(ex, "An error occurred while registering steps/custom APIs after package upload.");
-                return PluginRegistrationResult.Failure("Plugin registration failed during follow-up registration of steps/custom APIs.");
+                return PluginRegistrationResult.Failure("Plugin registration failed during follow-up registration of steps/custom APIs. Please check the Output window for more details.");
             }
         }
 


### PR DESCRIPTION
#### PR Classification
API change and analyzer enhancement for improved plugin step attribute validation and logging.

#### PR Summary
This PR introduces explicit enums for plugin step registration, enforces correct usage via analyzer logic, and improves exception logging. 
- XrmTools.Meta.Attributes: Added Stages and ExecutionMode enums; StepAttribute now requires explicit stage and mode.
- XrmToolsAnalyzersUnitTests.cs: Updated tests to use new StepAttribute constructors and added tests for the new analyzer rule.
- PluginDependencyAnalyzer.cs: Added XrmTools006 analyzer to warn on invalid async step registration in PreValidation/PreOperation.
- OutputLogger.cs: Added AppendException method for consistent exception logging.
- PluginRegistrationService.cs: Improved error message for step/custom API registration failures.
