### PR TITLE
Fix: [Plugin] expansion truncated for multi-step multi-image registrations

### DIFF
--- a/src/XrmTools/CodeRefactoringProviders/WebApiServiceHelper.cs
+++ b/src/XrmTools/CodeRefactoringProviders/WebApiServiceHelper.cs
@@ -29,7 +29,7 @@ internal static class WebApiServiceHelper
                 "$select=sdkmessageprocessingstepimageid,name,imagetype,messagepropertyname,attributes,entityalias)," +
             "sdkmessagefilterid($select=primaryobjecttypecode)," +
             "sdkmessageid($select=name))";
-        var response = await webApi.RetrieveMultipleAsync<PluginType>(odataQuery, 2);
+        var response = await webApi.RetrieveMultipleAsync<PluginType>(odataQuery);
         return response?.Value?.FirstOrDefault();
     }
 }

--- a/src/XrmTools/Resources/Strings.Designer.cs
+++ b/src/XrmTools/Resources/Strings.Designer.cs
@@ -82,7 +82,7 @@ namespace XrmTools.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Input is empty. Code generation needs some input to generate code. Please make sure your have properly used attributes from XrmTools.Meta.Attributes.
+        ///   Looks up a localized string similar to Input is empty. Code generation needs some input to generate code. Please make sure you have used attributes from XrmTools.Meta.Attributes.
         ///Input file path: {0}.
         /// </summary>
         internal static string CodeGen_InputModel_Empty {

--- a/src/XrmTools/Resources/Strings.resx
+++ b/src/XrmTools/Resources/Strings.resx
@@ -199,7 +199,7 @@ File path: {0}
 Error: {1}</value>
   </data>
   <data name="CodeGen.InputModel_Empty" xml:space="preserve">
-    <value>Input is empty. Code generation needs some input to generate code. Please make sure your have properly used attributes from XrmTools.Meta.Attributes.
+    <value>Input is empty. Code generation needs some input to generate code. Please make sure you have used attributes from XrmTools.Meta.Attributes.
 Input file path: {0}</value>
   </data>
   <data name="CodeGen.InputFileOrProjectMissing" xml:space="preserve">


### PR DESCRIPTION
Remove explicit record limit in RetrieveMultipleAsync call

The RetrieveMultipleAsync<PluginType> method call no longer specifies a limit of 2 records, allowing it to use the default behavior for result count or page size. This change may affect the number of records retrieved by default.

Correct mispelling in an error log.