### PR TITLE
Improve GetLabel fallback logic and add comprehensive tests

### DIFF
--- a/src/Tests/XrmTools.Tests/Xrm/Generators/ScribanExtensionsTests.cs
+++ b/src/Tests/XrmTools.Tests/Xrm/Generators/ScribanExtensionsTests.cs
@@ -1,0 +1,72 @@
+﻿namespace XrmTools.Tests.Xrm.Generators;
+
+using FluentAssertions;
+using XrmTools.WebApi.Types;
+using XrmTools.Xrm.Generators;
+using Xunit;
+
+public class ScribanExtensionsTests
+{
+    [Fact]
+    public void GetLabel_ReturnsRequestedLanguage_WhenPresent()
+    {
+        var label = new Label
+        {
+            LocalizedLabels =
+            [
+                new LocalizedLabel { LanguageCode = 1036, Label = "Statut" },
+                new LocalizedLabel { LanguageCode = 1033, Label = "Status" },
+            ]
+        };
+
+        ScribanExtensions.GetLabel(label, 1033).Should().Be("Status");
+    }
+
+    [Fact]
+    public void GetLabel_FallsBackToUserLocalizedLabel_WhenRequestedLanguageMissing()
+    {
+        var label = new Label
+        {
+            UserLocalizedLabel = new LocalizedLabel { LanguageCode = 1036, Label = "Statut" },
+            LocalizedLabels =
+            [
+                new LocalizedLabel { LanguageCode = 1036, Label = "Statut" },
+            ]
+        };
+
+        ScribanExtensions.GetLabel(label, 1033).Should().Be("Statut");
+    }
+
+    [Fact]
+    public void GetLabel_FallsBackToFirstNonEmptyLabel_WhenRequestedAndUserLabelMissing()
+    {
+        var label = new Label
+        {
+            UserLocalizedLabel = new LocalizedLabel { LanguageCode = 1036, Label = string.Empty },
+            LocalizedLabels =
+            [
+                new LocalizedLabel { LanguageCode = 1036, Label = "Statut" },
+            ]
+        };
+
+        ScribanExtensions.GetLabel(label, 1033).Should().Be("Statut");
+    }
+
+    [Fact]
+    public void GetLabel_ReturnsNull_WhenLabelIsNull()
+    {
+        ScribanExtensions.GetLabel(null, 1033).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetLabel_ReturnsNull_WhenNoLabelsAvailable()
+    {
+        var label = new Label
+        {
+            UserLocalizedLabel = new LocalizedLabel { Label = string.Empty },
+            LocalizedLabels = []
+        };
+
+        ScribanExtensions.GetLabel(label, 1033).Should().BeNull();
+    }
+}

--- a/src/XrmTools/Xrm/Generators/ScribanExtensions.cs
+++ b/src/XrmTools/Xrm/Generators/ScribanExtensions.cs
@@ -147,8 +147,24 @@ public static class ScribanExtensions
 
     public static bool IsEnumAttribute(AttributeMetadata a) => (a.AttributeType is AttributeTypeCode.Picklist or AttributeTypeCode.Virtual or AttributeTypeCode.State or AttributeTypeCode.Status or AttributeTypeCode.EntityName) && a.IsLogical == false;
 
+    /// <summary>
+    /// Resolves a localized label for the requested language, falling back to the user-localized
+    /// label (typically the environment base language) and then to any available non-empty label.
+    /// This prevents empty identifiers/labels in generated code when an option set has no label for
+    /// the requested language (e.g. no English/1033 label in a non-English environment).
+    /// </summary>
     public static string? GetLabel(Label? label, int language)
-       => label?.LocalizedLabels?.FirstOrDefault(l => l.LanguageCode == language)?.Label;
+    {
+        if (label is null) return null;
+
+        var requested = label.LocalizedLabels?.FirstOrDefault(l => l.LanguageCode == language)?.Label;
+        if (!string.IsNullOrEmpty(requested)) return requested;
+
+        var userLocalized = label.UserLocalizedLabel?.Label;
+        if (!string.IsNullOrEmpty(userLocalized)) return userLocalized;
+
+        return label.LocalizedLabels?.FirstOrDefault(l => !string.IsNullOrEmpty(l.Label))?.Label;
+    }
 
     public static string EscapeVerbatim(string input)
         => string.IsNullOrEmpty(input) ? string.Empty : input.Replace("\"", "\"\"");


### PR DESCRIPTION
Improve GetLabel fallback logic and add comprehensive tests

Refactored ScribanExtensions.GetLabel to enhance label resolution: it now prioritizes the requested language, then user-localized, and finally any non-empty label, avoiding empty or missing labels in generated code. Added ScribanExtensionsTests to cover these scenarios and updated documentation to clarify the fallback logic.