### PR TITLE
fix(codegen): avoid CS0542 when an entity and one of its columns share a name

### DIFF
--- a/src/Templates/XrmTools.PluginProjectTemplate/ProjectTemplate.csproj
+++ b/src/Templates/XrmTools.PluginProjectTemplate/ProjectTemplate.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.PowerApps.MSBuild.Plugin" Version="1.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="XrmTools.Meta.Attributes" Version="1.1.7">
+    <PackageReference Include="XrmTools.Meta.Attributes" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tests/XrmTools.Tests/Analyzers/CSharpXrmMetaParserNameCollisionTests.cs
+++ b/src/Tests/XrmTools.Tests/Analyzers/CSharpXrmMetaParserNameCollisionTests.cs
@@ -1,0 +1,109 @@
+namespace XrmTools.Tests.Analyzers;
+
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XrmTools.Analyzers;
+using XrmTools.Meta.Model;
+using Xunit;
+
+public class CSharpXrmMetaParserNameCollisionTests
+{
+    [Fact]
+    public async Task ParsePluginAssemblyConfig_Should_Populate_NameCollisionSuffix_From_Assembly_Attribute()
+    {
+        var project = CreateProject(AssemblyInfoWithSuffix);
+        var compilation = await project.GetCompilationAsync();
+        compilation.Should().NotBeNull();
+
+        var parser = new CSharpXrmMetaParser(new CSharpDependencyAnalyzer(), new DependencyPreparation());
+        var config = parser.ParsePluginAssemblyConfig(compilation!);
+
+        config.Should().NotBeNull();
+        config!.NameCollision.Should().NotBeNull();
+        config.NameCollision.Suffix.Should().Be("Attribute");
+    }
+
+    [Fact]
+    public async Task ParsePluginAssemblyConfig_Should_DefaultNameCollisionSuffix_When_Attribute_Absent()
+    {
+        var project = CreateProject(AssemblyInfoWithoutSuffix);
+        var compilation = await project.GetCompilationAsync();
+        compilation.Should().NotBeNull();
+
+        var parser = new CSharpXrmMetaParser(new CSharpDependencyAnalyzer(), new DependencyPreparation());
+        var config = parser.ParsePluginAssemblyConfig(compilation!);
+
+        config.Should().NotBeNull();
+        config!.NameCollision.Suffix.Should().Be(CodeGenNameCollisionConfig.DefaultSuffix);
+    }
+
+    private static Project CreateProject(string assemblyInfoSource)
+    {
+        var workspace = CreateWorkspace();
+        var project = workspace.AddProject("NameCollisionProject", LanguageNames.CSharp)
+            .AddMetadataReferences(GetMetadataReferences());
+
+        project = project.AddDocument("Attributes.cs", AttributeSource, filePath: Path.Combine("C:\\", "Tests", "Attributes.cs")).Project;
+        project = project.AddDocument("AssemblyInfo.cs", assemblyInfoSource, filePath: Path.Combine("C:\\", "Tests", "AssemblyInfo.cs")).Project;
+
+        return project;
+    }
+
+    private static AdhocWorkspace CreateWorkspace()
+    {
+        var host = MefHostServices.Create(
+            MefHostServices.DefaultAssemblies.Concat(
+            [
+                typeof(CSharpCompilation).Assembly,
+                typeof(CSharpFormattingOptions).Assembly,
+            ]));
+
+        return new AdhocWorkspace(host);
+    }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+        =>
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+        ];
+
+    private const string AttributeSource = @"namespace XrmTools.Meta.Attributes;
+
+using System;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+internal sealed class PluginAssemblyAttribute : Attribute
+{
+    public int SourceType { get; set; }
+    public int IsolationMode { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+internal sealed class CodeGenNameCollisionSuffixAttribute : Attribute
+{
+    public string Suffix { get; set; }
+
+    public CodeGenNameCollisionSuffixAttribute(string suffix)
+    {
+        Suffix = suffix;
+    }
+}";
+
+    private const string AssemblyInfoWithSuffix = @"using XrmTools.Meta.Attributes;
+
+[assembly: PluginAssembly]
+[assembly: CodeGenNameCollisionSuffix(""Attribute"")]";
+
+    private const string AssemblyInfoWithoutSuffix = @"using XrmTools.Meta.Attributes;
+
+[assembly: PluginAssembly]";
+}

--- a/src/Tests/XrmTools.Tests/CodeGen/CodeGenNamingTests.cs
+++ b/src/Tests/XrmTools.Tests/CodeGen/CodeGenNamingTests.cs
@@ -1,0 +1,110 @@
+﻿namespace XrmTools.Tests.CodeGen;
+
+using System.Collections.Generic;
+using FluentAssertions;
+using XrmTools;
+using XrmTools.WebApi.Entities;
+using XrmTools.WebApi.Types;
+using Xunit;
+
+public class CodeGenNamingTests
+{
+    private static AttributeMetadata Attribute(string schemaName, string logicalName) => new()
+    {
+        SchemaName = schemaName,
+        LogicalName = logicalName,
+        AttributeType = AttributeTypeCode.String
+    };
+
+    private static EntityMetadata Entity(string schemaName, params AttributeMetadata[] attributes) =>
+        new("xxx_postalcode", "xxx_postalcodes")
+        {
+            SchemaName = schemaName,
+            Attributes = attributes
+        };
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_RenamesAttributeMatchingEnclosingType()
+    {
+        var colliding = Attribute("PostalCode", "xxx_postalcode");
+        var entity = Entity("PostalCode", colliding, Attribute("Name", "xxx_name"));
+
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entity, entity.Attributes);
+
+        colliding.SchemaName.Should().Be("PostalCodeValue");
+        entity.SchemaName.Should().Be("PostalCode");
+    }
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_LeavesNonCollidingAttributesUntouched()
+    {
+        var name = Attribute("Name", "xxx_name");
+        var code = Attribute("Code", "xxx_code");
+        var entity = Entity("PostalCode", name, code);
+
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entity, entity.Attributes);
+
+        name.SchemaName.Should().Be("Name");
+        code.SchemaName.Should().Be("Code");
+    }
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_DisambiguatesWhenSuffixedNameAlreadyExists()
+    {
+        var colliding = Attribute("PostalCode", "xxx_postalcode");
+        var existing = Attribute("PostalCodeValue", "xxx_postalcodevalue");
+        var entity = Entity("PostalCode", colliding, existing);
+
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entity, entity.Attributes);
+
+        colliding.SchemaName.Should().Be("PostalCodeValue1");
+        existing.SchemaName.Should().Be("PostalCodeValue");
+    }
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_UsesConfiguredSuffix()
+    {
+        var colliding = Attribute("PostalCode", "xxx_postalcode");
+        var entity = Entity("PostalCode", colliding, Attribute("Name", "xxx_name"));
+
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entity, entity.Attributes, "Attribute");
+
+        colliding.SchemaName.Should().Be("PostalCodeAttribute");
+    }
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_FallsBackToDefaultSuffix_WhenConfiguredSuffixIsBlank()
+    {
+        var colliding = Attribute("PostalCode", "xxx_postalcode");
+        var entity = Entity("PostalCode", colliding);
+
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entity, entity.Attributes, "   ");
+
+        colliding.SchemaName.Should().Be("PostalCodeValue");
+    }
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_ComparisonIsCaseSensitive()
+    {
+        // "postalcode" (lower) is a distinct C# identifier from the type "PostalCode",
+        // so it must not be renamed.
+        var different = Attribute("postalcode", "xxx_postalcode2");
+        var entity = Entity("PostalCode", different);
+
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entity, entity.Attributes);
+
+        different.SchemaName.Should().Be("postalcode");
+    }
+
+    [Fact]
+    public void ResolveEnclosingTypeNameCollisions_HandlesNullArguments()
+    {
+        var act = () =>
+        {
+            CodeGenNaming.ResolveEnclosingTypeNameCollisions(null, new List<AttributeMetadata>());
+            CodeGenNaming.ResolveEnclosingTypeNameCollisions(Entity("PostalCode"), null);
+        };
+
+        act.Should().NotThrow();
+    }
+}

--- a/src/XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj
+++ b/src/XrmTools.Meta.Attributes.Package/XrmTools.Meta.Attributes.Package.msbuildproj
@@ -8,7 +8,7 @@
 	<Title>XrmTools.Meta.Attributes</Title>
 	<Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
 	<PackageId>XrmTools.Meta.Attributes</PackageId>
-	<VersionPrefix>1.1.7</VersionPrefix>
+	<VersionPrefix>1.2.0</VersionPrefix>
 	<Authors>Reza Niroomand</Authors>
 	<PackageIcon>XrmTools_256.png</PackageIcon>
 	<PackageTags>Power Platform Apps XRM Tools</PackageTags>

--- a/src/XrmTools.Meta.Attributes/README.md
+++ b/src/XrmTools.Meta.Attributes/README.md
@@ -58,6 +58,7 @@ It's a lot easier to add early-bound (typed) entities to your project. Just add 
 You can fine-tune code generation in Xrm Tools by adding the following global attributes to your `Assemblyinfo.cs` or any global `.cs` file.
 - `CodeGenReplacePrefixesAttribute`: Assembly scoped attribute that instructs the code generator to replace or remove the prefixes of the entity names with the given values. This is useful when you want to use a different prefix for your entities or remove prefixes in the generated code.
 - `CodeGenGlobalOptionSetAttribute`: Assembly scoped attribute that lets the developer decide if global option sets should be generated in the GlobalOptionSets.cs file or as enums in the typed entity files. By default, global option sets are generated locally.
+- `CodeGenNameCollisionSuffixAttribute`: Assembly scoped attribute that sets the suffix appended to a generated property when its name would otherwise clash with the name of its enclosing type. This happens when a Dataverse column shares the logical name of its table (e.g. a table `xxx_postalcode` with a column `xxx_postalcode`), which C# does not allow. The default suffix is `Value` (so the column above becomes a `PostalCodeValue` property); use this attribute to choose another, e.g. `[assembly: CodeGenNameCollisionSuffix("Attribute")]`.
 
 ### Other Global Attributes
 - `PluginAssemblyAttribute`: You can optionally customize the assembly level registration by adding this attribute to your `AssemblyInfor.cs` or any other global `.cs` file.

--- a/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
+++ b/src/XrmTools.Meta.Attributes/XrmTools.Meta.Attributes.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Description>Attributes to be used by Xrm Tools for source generation, registration and other features in Visual Studio. This is a source only package with no assemblies included.</Description>
     <Authors>Reza Niroomand</Authors>
     <PackageIcon>XrmTools_256.png</PackageIcon>

--- a/src/XrmTools.Meta.Attributes/src/CodeGenNameCollisionSuffixAttribute.cs
+++ b/src/XrmTools.Meta.Attributes/src/CodeGenNameCollisionSuffixAttribute.cs
@@ -1,0 +1,25 @@
+namespace XrmTools.Meta.Attributes
+{
+    using System;
+
+    /// <summary>
+    /// Specifies the suffix appended to a generated member (property) name when it would otherwise
+    /// be identical to the name of its enclosing type. This situation occurs when a Dataverse column
+    /// shares the logical/schema name of its table (e.g. a table "xxx_postalcode" containing a column
+    /// "xxx_postalcode"), which C# forbids (compiler error CS0542). When omitted, the default suffix
+    /// "Value" is used, so the column above generates a property named "PostalCodeValue".
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    internal class CodeGenNameCollisionSuffixAttribute : Attribute
+    {
+        /// <summary>
+        /// The suffix to append to a generated member name that collides with its enclosing type name.
+        /// </summary>
+        public string Suffix { get; set; }
+
+        public CodeGenNameCollisionSuffixAttribute(string suffix)
+        {
+            Suffix = suffix;
+        }
+    }
+}

--- a/src/XrmTools.Meta/Model/CodeGenNameCollisionConfig.cs
+++ b/src/XrmTools.Meta/Model/CodeGenNameCollisionConfig.cs
@@ -1,0 +1,12 @@
+﻿namespace XrmTools.Meta.Model;
+
+public class CodeGenNameCollisionConfig
+{
+    /// <summary>
+    /// Default suffix appended to a generated member name that would otherwise collide with the
+    /// name of its enclosing type.
+    /// </summary>
+    public const string DefaultSuffix = "Value";
+
+    public string Suffix { get; set; } = DefaultSuffix;
+}

--- a/src/XrmTools.Meta/Model/Configuration/PluginAssemblyConfig.cs
+++ b/src/XrmTools.Meta/Model/Configuration/PluginAssemblyConfig.cs
@@ -56,6 +56,9 @@ public sealed class PluginAssemblyConfig : PluginAssembly//, IPluginAssemblyConf
     [JsonPropertyOrder(3)]
     public CodeGenOrganizationContextConfig? OrganizationContextConfig { get; set; } = new();
 
+    [JsonPropertyOrder(4)]
+    public CodeGenNameCollisionConfig NameCollision { get; set; } = new();
+
     public Solution? Solution { get; set; }
 
     public new ICollection<PluginTypeConfig> PluginTypes { get; set; } = [];

--- a/src/XrmTools/Analyzers/CSharpXrmMetaParser.cs
+++ b/src/XrmTools/Analyzers/CSharpXrmMetaParser.cs
@@ -53,6 +53,7 @@ internal class CSharpXrmMetaParser(
         List<AttributeData> codeGenPrefixAttribute = [];
         AttributeData? codeGenGlobalOptionSetsAttribute = null;
         AttributeData? codeGenOrgContextAttribute = null;
+        AttributeData? codeGenNameCollisionAttribute = null;
         //List<EntityConfig> entityConfigs = [];
         foreach (var attr in assemblySymbol.GetAttributes())
         {
@@ -75,6 +76,10 @@ internal class CSharpXrmMetaParser(
             else if (attr.AttributeClass?.ToDisplayString() == typeof(CodeGenOrganizationContextAttribute).FullName)
             {
                 codeGenOrgContextAttribute = attr;
+            }
+            else if (attr.AttributeClass?.ToDisplayString() == typeof(CodeGenNameCollisionSuffixAttribute).FullName)
+            {
+                codeGenNameCollisionAttribute = attr;
             }
             //else if (attr.AttributeClass?.ToDisplayString() == typeof(EntityAttribute).FullName)
             //{
@@ -125,6 +130,11 @@ internal class CSharpXrmMetaParser(
         else
         {
             pluginAssemblyConfig.OrganizationContextConfig = null;
+        }
+
+        if (codeGenNameCollisionAttribute != null)
+        {
+            pluginAssemblyConfig.NameCollision.SetPropertiesFromAttribute(codeGenNameCollisionAttribute);
         }
 
         if (assemblyAttribute == null) return pluginAssemblyConfig;

--- a/src/XrmTools/CodeGen/CodeGenNaming.cs
+++ b/src/XrmTools/CodeGen/CodeGenNaming.cs
@@ -1,0 +1,71 @@
+﻿#nullable enable
+namespace XrmTools;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using XrmTools.WebApi.Entities;
+
+/// <summary>
+/// Helpers that make generated member names valid C# identifiers within the context of the
+/// type that contains them.
+/// </summary>
+internal static class CodeGenNaming
+{
+    /// <summary>
+    /// Default suffix appended to a generated member (property) name when it would otherwise be
+    /// identical to the name of its enclosing type. C# forbids a member from having the same name as
+    /// the type that contains it (compiler error CS0542), which happens when a Dataverse column
+    /// shares the logical/schema name of its table (e.g. a table "xxx_postalcode" with a column
+    /// "xxx_postalcode"). Can be overridden per-assembly via <c>[assembly: CodeGenNameCollisionSuffix(...)]</c>.
+    /// </summary>
+    private const string DefaultEnclosingTypeCollisionSuffix = "Value";
+
+    /// <summary>
+    /// Ensures no attribute's schema name (which becomes a generated property name) is identical to
+    /// the entity's schema name (which becomes the enclosing type name). Colliding attributes are
+    /// renamed by appending <paramref name="suffix"/> (defaulting to "Value" when null/empty),
+    /// disambiguating with a numeric suffix if the resulting name is already taken by another
+    /// attribute.
+    /// <para>
+    /// This must run after the entity and attribute schema names have been formatted (prefixes
+    /// removed and first letter capitalized), so the comparison reflects the names that will
+    /// actually be emitted.
+    /// </para>
+    /// </summary>
+    public static void ResolveEnclosingTypeNameCollisions(EntityMetadata? entityDefinition, IEnumerable<AttributeMetadata>? attributes, string? suffix = null)
+    {
+        if (entityDefinition?.SchemaName is not { Length: > 0 } typeName || attributes is null) return;
+
+        var effectiveSuffix = string.IsNullOrWhiteSpace(suffix) ? DefaultEnclosingTypeCollisionSuffix : suffix!.Trim();
+
+        var attributeList = attributes as IList<AttributeMetadata> ?? attributes.ToList();
+
+        var usedNames = new HashSet<string>(StringComparer.Ordinal) { typeName };
+        foreach (var attribute in attributeList)
+        {
+            if (attribute.SchemaName is { Length: > 0 } schemaName)
+            {
+                usedNames.Add(schemaName);
+            }
+        }
+
+        foreach (var attribute in attributeList)
+        {
+            if (!string.Equals(attribute.SchemaName, typeName, StringComparison.Ordinal)) continue;
+
+            var candidate = typeName + effectiveSuffix;
+            var counter = 1;
+            while (usedNames.Contains(candidate))
+            {
+                candidate = typeName + effectiveSuffix + counter.ToString(CultureInfo.InvariantCulture);
+                counter++;
+            }
+
+            attribute.SchemaName = candidate;
+            usedNames.Add(candidate);
+        }
+    }
+}
+#nullable restore

--- a/src/XrmTools/CodeGen/EntityCodeGenerator.cs
+++ b/src/XrmTools/CodeGen/EntityCodeGenerator.cs
@@ -279,6 +279,7 @@ public sealed class EntityCodeGenerator : BaseCodeGeneratorWithSiteAsync
                 entityConfig.LogicalName!,
                 entityConfig.AttributeNames?.Split(',') ?? [],
                 config.ReplacePrefixes,
+                config.NameCollision.Suffix,
                 ct).ConfigureAwait(false);
             if (entityMetadata != null)
             {
@@ -287,7 +288,7 @@ public sealed class EntityCodeGenerator : BaseCodeGeneratorWithSiteAsync
         }
     }
 
-    private async Task<EntityMetadata?> GetEntityMetadataAsync(string logicalName, IEnumerable<string> attributeNames, Meta.Model.CodeGenReplacePrefixConfig[] prefixReplacements, CancellationToken ct)
+    private async Task<EntityMetadata?> GetEntityMetadataAsync(string logicalName, IEnumerable<string> attributeNames, Meta.Model.CodeGenReplacePrefixConfig[] prefixReplacements, string collisionSuffix, CancellationToken ct)
     {
         using var entityMetadataRepo = RepositoryFactory.CreateRepository<IEntityMetadataRepository>();
         if (entityMetadataRepo is null) return null;
@@ -306,6 +307,7 @@ public sealed class EntityCodeGenerator : BaseCodeGeneratorWithSiteAsync
 
         FormatAttributeSchemaNames(filteredAttributes ?? entityDefinition.Attributes!, prefixReplacements);
         FormatEntitySchemaName(entityDefinition, prefixReplacements);
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entityDefinition, filteredAttributes ?? entityDefinition.Attributes!, collisionSuffix);
 
         // The cloning is done because we don't want to modify the object in the cache.
         // In future when we load from local storage this might not be required.

--- a/src/XrmTools/CodeGen/PluginCodeGenerator.cs
+++ b/src/XrmTools/CodeGen/PluginCodeGenerator.cs
@@ -196,7 +196,7 @@ public class PluginCodeGenerator : BaseCodeGeneratorWithSiteAsync
         return null;
     }
 
-    private async Task<EntityMetadata?> GetEntityMetadataAsync(string logicalName, IEnumerable<string> attributeNames, CodeGenReplacePrefixConfig[] prefixReplacements, CancellationToken ct)
+    private async Task<EntityMetadata?> GetEntityMetadataAsync(string logicalName, IEnumerable<string> attributeNames, CodeGenReplacePrefixConfig[] prefixReplacements, string collisionSuffix, CancellationToken ct)
     {
         using var entityMetadataRepo = RepositoryFactory.CreateRepository<IEntityMetadataRepository>();
         if (entityMetadataRepo is null) return null;
@@ -213,6 +213,7 @@ public class PluginCodeGenerator : BaseCodeGeneratorWithSiteAsync
 
         FormatAttributeSchemaNames(filteredAttributes ?? entityDefinition.Attributes ?? [], prefixReplacements);
         FormatEntitySchemaName(entityDefinition, prefixReplacements);
+        CodeGenNaming.ResolveEnclosingTypeNameCollisions(entityDefinition, filteredAttributes ?? entityDefinition.Attributes ?? [], collisionSuffix);
 
         // The cloning is done because we don't want to modify the object in the cache.
         // In future when we load from local storage this might not be required.
@@ -313,7 +314,7 @@ public class PluginCodeGenerator : BaseCodeGeneratorWithSiteAsync
                 // We have some attributes already, so we add the new ones too.
                 entitiesAndAttributes[step.PrimaryEntityName!].UnionWith(filteringAttributes);
             }
-            var entityDefinition = await GetEntityMetadataAsync(step.PrimaryEntityName!, filteringAttributes, config.ReplacePrefixes, ct).ConfigureAwait(false);
+            var entityDefinition = await GetEntityMetadataAsync(step.PrimaryEntityName!, filteringAttributes, config.ReplacePrefixes, config.NameCollision.Suffix, ct).ConfigureAwait(false);
             step.PrimaryEntityDefinition = entityDefinition;
 
             foreach (var image in step.Images)
@@ -335,7 +336,7 @@ public class PluginCodeGenerator : BaseCodeGeneratorWithSiteAsync
                 {
                     entitiesAndAttributes[step.PrimaryEntityName!].UnionWith(imageAttributes);
                 }
-                entityDefinition = await GetEntityMetadataAsync(step.PrimaryEntityName!, imageAttributes, config.ReplacePrefixes, ct).ConfigureAwait(false);
+                entityDefinition = await GetEntityMetadataAsync(step.PrimaryEntityName!, imageAttributes, config.ReplacePrefixes, config.NameCollision.Suffix, ct).ConfigureAwait(false);
                 image.MessagePropertyDefinition = entityDefinition;
             }
         }
@@ -343,14 +344,14 @@ public class PluginCodeGenerator : BaseCodeGeneratorWithSiteAsync
         foreach (var entityEntry in entitiesAndAttributes)//.Where(e => e.Value.Count > 0))
         {
             ct.ThrowIfCancellationRequested();
-            entityDefinitions[entityEntry.Key] = await GetEntityMetadataAsync(entityEntry.Key, entityEntry.Value, config.ReplacePrefixes, ct).ConfigureAwait(false);
+            entityDefinitions[entityEntry.Key] = await GetEntityMetadataAsync(entityEntry.Key, entityEntry.Value, config.ReplacePrefixes, config.NameCollision.Suffix, ct).ConfigureAwait(false);
         }
         foreach (var entityConfig in config.Entities)
         {
             ct.ThrowIfCancellationRequested();
             if (!string.IsNullOrEmpty(entityConfig.LogicalName))
             {
-                entityDefinitions[entityConfig.LogicalName!] = await GetEntityMetadataAsync(entityConfig.LogicalName!, entityConfig.AttributeNames?.SplitAndTrim(',') ?? [], config.ReplacePrefixes, ct).ConfigureAwait(false)!;
+                entityDefinitions[entityConfig.LogicalName!] = await GetEntityMetadataAsync(entityConfig.LogicalName!, entityConfig.AttributeNames?.SplitAndTrim(',') ?? [], config.ReplacePrefixes, config.NameCollision.Suffix, ct).ConfigureAwait(false)!;
             }
         }
         config.EntityDefinitions = entityDefinitions.Values;

--- a/src/XrmTools/CustomMonikers.imagemanifest
+++ b/src/XrmTools/CustomMonikers.imagemanifest
@@ -3,7 +3,7 @@
 <!-- Version: 17.0.0.4 -->
 <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
-    <String Name="Resources" Value="/XrmTools;v1.7.0.0;Component/Resources" />
+    <String Name="Resources" Value="/XrmTools;v2.0.0.0;Component/Resources" />
     <Guid Name="AssetsGuid" Value="{b11584c1-89bd-47a3-b6a4-05b05dd5fc13}" />
     <ID Name="ApplyToDataverse" Value="10" />
     <ID Name="Dataverse" Value="20" />

--- a/src/XrmTools/NuGet/NuGetAuditor.cs
+++ b/src/XrmTools/NuGet/NuGetAuditor.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 internal sealed class NuGetAuditor
 {
-    private const string MinimumVersion = "1.1.7";
+    private const string MinimumVersion = "1.2.0";
 
     public async Task AuditAsync(CancellationToken ct)
     {

--- a/src/XrmTools/XrmTools.csproj
+++ b/src/XrmTools/XrmTools.csproj
@@ -67,6 +67,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Compile Include="CodeGen\BaseCodeGeneratorWithSiteAsync.cs" />
+    <Compile Include="CodeGen\CodeGenNaming.cs" />
     <Compile Include="CodeGen\EntityCodeGenerator.cs" />
     <Compile Include="CodeRefactoringProviders\PluginRefactoringProvider.cs" />
     <Compile Include="CodeRefactoringProviders\PropertyGenerator.cs" />

--- a/src/XrmTools/source.extension.cs
+++ b/src/XrmTools/source.extension.cs
@@ -12,7 +12,7 @@ namespace XrmTools
         public const string Name = "Xrm Tools";
         public const string Description = @"Xrm Tools is a Visual Studio extension that makes Power Platform development feel native, with IntelliSense for plugins, boilerplate and typed entity generation, and first-class FetchXML support.";
         public const string Language = "en-US";
-        public const string Version = "1.7.0";
+        public const string Version = "2.0.0";
         public const string Author = "Reza Niroomand";
         public const string Tags = "Power Platform, Dataverse, Power Apps, XRM";
         public const bool IsPreview = false;

--- a/src/XrmTools/source.extension.vsixmanifest
+++ b/src/XrmTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="XrmTools.eba3cd26-ffad-444f-b4ef-771d430bacef" Version="1.7.0" Language="en-US" Publisher="Reza Niroomand" />
+    <Identity Id="XrmTools.eba3cd26-ffad-444f-b4ef-771d430bacef" Version="2.0.0" Language="en-US" Publisher="Reza Niroomand" />
     <DisplayName>Xrm Tools</DisplayName>
     <Description xml:space="preserve">Xrm Tools is a Visual Studio extension that makes Power Platform development feel native, with IntelliSense for plugins, boilerplate and typed entity generation, and first-class FetchXML support.</Description>
     <MoreInfo>https://github.com/rezanid/xrmtools</MoreInfo>


### PR DESCRIPTION
fix(codegen): avoid CS0542 when an entity and one of its columns share a name

Generating a typed entity whose class name matches one of its own property
names produced C# that fails to compile with CS0542 ("member names cannot be
the same as their enclosing type"). This happens when a Dataverse column has
the same logical name as its table (e.g. table `xxx_postalcode` with a column
`xxx_postalcode`).

The entity and attribute schema names are formatted independently in both the
entity and plugin generators, so the collision was never detected. Add a
CodeGenNaming.ResolveEnclosingTypeNameCollisions helper that runs after
formatting and renames the colliding attribute (property, Fields const, nameof
and field map all derive from the same value, so they stay consistent). The
comparison is Ordinal to match C# identifier rules, and a numeric suffix is
appended if the disambiguated name already exists.

The suffix defaults to "Value" (so the column above becomes `PostalCodeValue`)
and is configurable per assembly via the new
[assembly: CodeGenNameCollisionSuffix("...")] attribute, wired through the
CSharpXrmMetaParser into PluginAssemblyConfig.NameCollision and threaded into
both generators.

Ship the new attribute in XrmTools.Meta.Attributes 1.2.0 and update the plugin
project template reference to match.